### PR TITLE
Use `texture_path` argument

### DIFF
--- a/src/TileMap.cpp
+++ b/src/TileMap.cpp
@@ -18,7 +18,7 @@ sf::Sprite CreateTileSprite(int tile_map_x, int tile_map_y, int scale, int size,
 
 TileMap* CreateTileMap (std::string texture_path, int scale, int size, int cols, int rows) {
 	sf::Texture* texture = new sf::Texture();
-	if (!texture->loadFromFile("./assets/tilemap.png")) {
+	if (!texture->loadFromFile(texture_path)) {
 		std::cout << "Can't laod file" << std::endl;
 		exit(1);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv)
     int tile_size = 16;
     sf::RenderWindow window(sf::VideoMode(window_width, window_height), "SFML works!");
     TileMap* tile_map = CreateTileMap(
-            "../assets/tilemap.png", 
+            "./assets/tilemap.png", 
             4, // Tile scale factor
             tile_size, // Pixel size of tile in tilemap texture
             5,


### PR DESCRIPTION
Use the `texture_path` argument passed to `CreateTileMap`, and
update the call-site to match the expected asset path.