### PR TITLE
C++ encapsulation

### DIFF
--- a/headers/Editor.h
+++ b/headers/Editor.h
@@ -7,7 +7,7 @@
 /**
  * An editor contains all data required to add, remove and edit tiles on a given map
  */
-struct Editor {
+class Editor {
     // The blue rect around the selected tile in the tile palette
     sf::RectangleShape* selection_rectangle;	
 
@@ -43,6 +43,7 @@ struct Editor {
 
     sf::RenderTexture* room_render_texture;
 
+public:
     Editor(TileMap &, int, int);
     ~Editor();
 

--- a/headers/Editor.h
+++ b/headers/Editor.h
@@ -45,10 +45,10 @@ struct Editor {
 
     Editor(TileMap &, int, int);
     ~Editor();
+
+    void DrawEditor(sf::RenderTarget &, Room &);
+
+    void UpdateEditor(const sf::Event &, Room&, const sf::Vector2i);
 };
-
-void DrawEditor(sf::RenderTarget &, Editor &, Room &);
-
-void UpdateEditor(Editor &, const sf::Event &, Room&, const sf::Vector2i);
 
 void WriteRoomToFile(Room &, std::string);

--- a/headers/Editor.h
+++ b/headers/Editor.h
@@ -50,5 +50,3 @@ struct Editor {
 
     void UpdateEditor(const sf::Event &, Room&, const sf::Vector2i);
 };
-
-void WriteRoomToFile(Room &, std::string);

--- a/headers/Room.h
+++ b/headers/Room.h
@@ -22,8 +22,10 @@ struct Room {
 	Room(std::string);
 	Room(int, int, int, int);
 	~Room();
-};
 
-void DrawRoom(sf::RenderTarget &, Room &, TileMap &);
+	void DrawRoom(sf::RenderTarget &, TileMap &);
+
+	void WriteRoomToFile(std::string);
+};
 
 

--- a/headers/TileMap.h
+++ b/headers/TileMap.h
@@ -3,10 +3,12 @@
 #include <SFML/Graphics.hpp>
 #include <iostream>
 
-struct TileMap {
+class TileMap {
+	sf::Texture* texture;
+
+public:
 	int size;
 	int scale;
-	sf::Texture* texture;
 	std::vector<sf::Sprite>* tiles;
 
 	TileMap(std::string, int, int, int, int);

--- a/src/Editor.cpp
+++ b/src/Editor.cpp
@@ -55,59 +55,59 @@ Editor::~Editor() {
     delete room_view;
 }
 
-void UpdateEditor(Editor& editor, const sf::Event& event, Room& room, const sf::Vector2i current_mouse_position) {
-    editor.selection_rectangle->setPosition((*editor.tiles)[editor.selected_tile_index].getPosition());
-    for(int i = 0; i < editor.tiles->size(); i ++) {
+void Editor::UpdateEditor(const sf::Event& event, Room& room, const sf::Vector2i current_mouse_position) {
+    selection_rectangle->setPosition((*tiles)[selected_tile_index].getPosition());
+    for(int i = 0; i < tiles->size(); i ++) {
         int current_y_pos = 
-            (i * editor.tile_map->scale * editor.tile_map->size) + 
-            (editor.offset * i) + editor.offset;
-        (*editor.tiles)[i].setPosition(editor.offset, current_y_pos);
+            (i * tile_map->scale * tile_map->size) + 
+            (offset * i) + offset;
+        (*tiles)[i].setPosition(offset, current_y_pos);
     }
 
-    sf::Vector2f current_target_coords = editor.room_render_texture->mapPixelToCoords(
+    sf::Vector2f current_target_coords = room_render_texture->mapPixelToCoords(
             sf::Vector2i(current_mouse_position.x, current_mouse_position.y)
     );
 
-    editor.current_mouse_grid_position->x = floor(current_target_coords.x / (editor.tile_map->size * editor.tile_map->scale));
-    editor.current_mouse_grid_position->y = floor(current_target_coords.y / (editor.tile_map->size * editor.tile_map->scale));
+    current_mouse_grid_position->x = floor(current_target_coords.x / (tile_map->size * tile_map->scale));
+    current_mouse_grid_position->y = floor(current_target_coords.y / (tile_map->size * tile_map->scale));
      
     if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Left) {
         // Manage Selection Changed
         int current_event_tile_index = 0;
-        for(sf::Sprite t : *editor.tiles) {
+        for(sf::Sprite t : *tiles) {
             bool in_current_bound = t.getGlobalBounds().contains(
-                editor.tile_palette_render_texture->mapPixelToCoords(sf::Vector2i(event.mouseButton.x, event.mouseButton.y))
+                tile_palette_render_texture->mapPixelToCoords(sf::Vector2i(event.mouseButton.x, event.mouseButton.y))
             );
 
             if(in_current_bound) {
-                editor.selected_tile_index = current_event_tile_index;		
+                selected_tile_index = current_event_tile_index;		
             }
             current_event_tile_index++;
         }
         
-        sf::Vector2f event_target_coords = editor.room_render_texture->mapPixelToCoords(
+        sf::Vector2f event_target_coords = room_render_texture->mapPixelToCoords(
             sf::Vector2i(event.mouseButton.x, event.mouseButton.y)
         );
         
         sf::IntRect pixel_bounds = sf::IntRect(
             0, 
             0, 
-            room.bounds.width * editor.tile_map->size * editor.tile_map->scale,
-            room.bounds.height * editor.tile_map->size * editor.tile_map->scale
+            room.bounds.width * tile_map->size * tile_map->scale,
+            room.bounds.height * tile_map->size * tile_map->scale
         );
 
 
         if (pixel_bounds.contains(sf::Vector2i(event_target_coords.x, event_target_coords.y)) && 
-            !editor.background->getGlobalBounds().contains(sf::Vector2f(event.mouseButton.x, event.mouseButton.y))
+            !background->getGlobalBounds().contains(sf::Vector2f(event.mouseButton.x, event.mouseButton.y))
         ) {
 
 
             for (auto it = room.tiles->begin(); it != room.tiles->end(); ) {
                 sf::FloatRect current_tile_bounds = sf::FloatRect(
-                    it->x * (editor.tile_map->size * editor.tile_map->scale),
-                    it->y * (editor.tile_map->size * editor.tile_map->scale),
-                    editor.tile_map->size * editor.tile_map->scale,
-                    editor.tile_map->size * editor.tile_map->scale
+                    it->x * (tile_map->size * tile_map->scale),
+                    it->y * (tile_map->size * tile_map->scale),
+                    tile_map->size * tile_map->scale,
+                    tile_map->size * tile_map->scale
                 );
                 
                 if (current_tile_bounds.contains(event_target_coords)) {
@@ -120,29 +120,29 @@ void UpdateEditor(Editor& editor, const sf::Event& event, Room& room, const sf::
 
             room.tiles->push_back(
                 Tile { 
-                    (int)floor(event_target_coords.x / (editor.tile_map->size * editor.tile_map->scale)),
-                    (int)floor(event_target_coords.y / (editor.tile_map->size * editor.tile_map->scale)),
-                    (int)editor.current_rotation,
-                    editor.selected_tile_index 
+                    (int)floor(event_target_coords.x / (tile_map->size * tile_map->scale)),
+                    (int)floor(event_target_coords.y / (tile_map->size * tile_map->scale)),
+                    (int)current_rotation,
+                    selected_tile_index 
                 }
             );
         }
     }
 
     if (event.type == sf::Event::MouseWheelMoved && 
-        event.mouseButton.x < editor.tile_palette_render_texture->getSize().x
+        event.mouseButton.x < tile_palette_render_texture->getSize().x
     ) {
-        int upper_scroll_center = editor.tile_palette_render_texture->getSize().y / 2;
+        int upper_scroll_center = tile_palette_render_texture->getSize().y / 2;
 
         // TODO : This does not appear in the window correctly there is around 50 px of black suggesting this is too long
-        int lower_scroll_center = editor.background->getSize().y - upper_scroll_center;
+        int lower_scroll_center = background->getSize().y - upper_scroll_center;
 
-        if (event.mouseWheel.delta < 0 && editor.tile_palette_view->getCenter().y > upper_scroll_center) {
-            editor.tile_palette_view->move(sf::Vector2f(0, 100 * event.mouseWheel.delta));
+        if (event.mouseWheel.delta < 0 && tile_palette_view->getCenter().y > upper_scroll_center) {
+            tile_palette_view->move(sf::Vector2f(0, 100 * event.mouseWheel.delta));
         }
 
-        if (event.mouseWheel.delta > 0 && editor.tile_palette_view->getCenter().y < lower_scroll_center) {
-            editor.tile_palette_view->move(sf::Vector2f(0, 100 * event.mouseWheel.delta));
+        if (event.mouseWheel.delta > 0 && tile_palette_view->getCenter().y < lower_scroll_center) {
+            tile_palette_view->move(sf::Vector2f(0, 100 * event.mouseWheel.delta));
         }
     }
 
@@ -151,33 +151,33 @@ void UpdateEditor(Editor& editor, const sf::Event& event, Room& room, const sf::
     }
 
     if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::Space) {
-        editor.panning = false;
+        panning = false;
     }
 
     if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Space) {
-        editor.panning = true;
+        panning = true;
     }
 
     if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Middle) {
-        editor.current_rotation += 90;
+        current_rotation += 90;
     }
 
     sf::Vector2i mouse_delta = sf::Vector2i(
-        current_mouse_position.x - editor.last_mouse_position.x, 
-        current_mouse_position.y - editor.last_mouse_position.y
+        current_mouse_position.x - last_mouse_position.x, 
+        current_mouse_position.y - last_mouse_position.y
     );
 
-    editor.last_mouse_position = current_mouse_position;
+    last_mouse_position = current_mouse_position;
 
-    if (editor.panning) {
-        editor.room_view->move(sf::Vector2f(mouse_delta.x * -1, mouse_delta.y * -1));
+    if (panning) {
+        room_view->move(sf::Vector2f(mouse_delta.x * -1, mouse_delta.y * -1));
     }
 
     if (event.type == sf::Event::Resized) {
         std::cout << event.size.width << std::endl;
-        editor.room_view->setSize(event.size.width, event.size.height);
-        editor.room_render_texture = new sf::RenderTexture();
-        editor.room_render_texture->create(event.size.width, event.size.height); 
+        room_view->setSize(event.size.width, event.size.height);
+        room_render_texture = new sf::RenderTexture();
+        room_render_texture->create(event.size.width, event.size.height); 
     }
  
 }
@@ -203,48 +203,48 @@ void DrawGrid(sf::RenderTarget &target, int grid_height, int grid_width, int siz
     }
 }
 
-void DrawEditor(sf::RenderTarget& target, Editor& editor, Room& room) {
+void Editor::DrawEditor(sf::RenderTarget& target, Room& room) {
     // Draw Room and Grid
-    editor.room_render_texture->setView(*editor.room_view);
-    editor.room_render_texture->clear();
-    DrawRoom(*editor.room_render_texture, room, *editor.tile_map);
+    room_render_texture->setView(*room_view);
+    room_render_texture->clear();
+    DrawRoom(*room_render_texture, room, *tile_map);
     DrawGrid(
-        *editor.room_render_texture, 
+        *room_render_texture, 
         room.bounds.height, 
         room.bounds.width, 
-        editor.tile_map->size * editor.tile_map->scale
+        tile_map->size * tile_map->scale
     );
 
     // Draw Selected Tile
-    sf::Sprite selected_tile_sprite((*editor.tile_map->tiles)[editor.selected_tile_index]);
-    selected_tile_sprite.setScale(sf::Vector2f(editor.tile_map->scale, editor.tile_map->scale));
-    int half_tile_size = editor.tile_map->size * editor.tile_map->scale / 2;
+    sf::Sprite selected_tile_sprite((*tile_map->tiles)[selected_tile_index]);
+    selected_tile_sprite.setScale(sf::Vector2f(tile_map->scale, tile_map->scale));
+    int half_tile_size = tile_map->size * tile_map->scale / 2;
     selected_tile_sprite.setPosition(
-        (editor.current_mouse_grid_position->x * editor.tile_map->size * editor.tile_map->scale) + half_tile_size,
-        (editor.current_mouse_grid_position->y * editor.tile_map->size * editor.tile_map->scale) + half_tile_size
+        (current_mouse_grid_position->x * tile_map->size * tile_map->scale) + half_tile_size,
+        (current_mouse_grid_position->y * tile_map->size * tile_map->scale) + half_tile_size
     );
     selected_tile_sprite.setColor(sf::Color(255, 255, 255, 170));
-    selected_tile_sprite.setOrigin(editor.tile_map->size / 2, editor.tile_map->size / 2);
-    selected_tile_sprite.rotate(editor.current_rotation);
-    editor.room_render_texture->draw(selected_tile_sprite);
+    selected_tile_sprite.setOrigin(tile_map->size / 2, tile_map->size / 2);
+    selected_tile_sprite.rotate(current_rotation);
+    room_render_texture->draw(selected_tile_sprite);
 
-    editor.room_render_texture->display();
+    room_render_texture->display();
 
-    sf::Sprite room_render_sprite(editor.room_render_texture->getTexture());
+    sf::Sprite room_render_sprite(room_render_texture->getTexture());
 
     sf::View current_window_view = target.getView();
     target.draw(room_render_sprite);
 
     //Draw Tile Palette
-    editor.tile_palette_render_texture->setView(*editor.tile_palette_view);
-    editor.tile_palette_render_texture->clear();
-    editor.tile_palette_render_texture->draw(*editor.background);
-    for(sf::Sprite tile_sprite : *editor.tiles) {
-        editor.tile_palette_render_texture->draw(tile_sprite);
+    tile_palette_render_texture->setView(*tile_palette_view);
+    tile_palette_render_texture->clear();
+    tile_palette_render_texture->draw(*background);
+    for(sf::Sprite tile_sprite : *tiles) {
+        tile_palette_render_texture->draw(tile_sprite);
     }
-    editor.tile_palette_render_texture->draw(*editor.selection_rectangle);
-    editor.tile_palette_render_texture->display();
-    sf::Sprite tile_palette_render_sprite(editor.tile_palette_render_texture->getTexture());
+    tile_palette_render_texture->draw(*selection_rectangle);
+    tile_palette_render_texture->display();
+    sf::Sprite tile_palette_render_sprite(tile_palette_render_texture->getTexture());
     target.draw(tile_palette_render_sprite);
 
 }

--- a/src/Editor.cpp
+++ b/src/Editor.cpp
@@ -147,7 +147,7 @@ void Editor::UpdateEditor(const sf::Event& event, Room& room, const sf::Vector2i
     }
 
     if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::W) {
-        WriteRoomToFile(room, "./assets/maps/room.bin");
+        room.WriteRoomToFile("./assets/maps/room.bin");
     }
 
     if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::Space) {
@@ -207,7 +207,7 @@ void Editor::DrawEditor(sf::RenderTarget& target, Room& room) {
     // Draw Room and Grid
     room_render_texture->setView(*room_view);
     room_render_texture->clear();
-    DrawRoom(*room_render_texture, room, *tile_map);
+    room.DrawRoom(*room_render_texture, *tile_map);
     DrawGrid(
         *room_render_texture, 
         room.bounds.height, 
@@ -247,58 +247,4 @@ void Editor::DrawEditor(sf::RenderTarget& target, Room& room) {
     sf::Sprite tile_palette_render_sprite(tile_palette_render_texture->getTexture());
     target.draw(tile_palette_render_sprite);
 
-}
-
-void WriteRoomToFile(Room& room, std::string file_name) {
-    std::ofstream wf(file_name, std::ios::out | std::ios::binary);
-
-    if(!wf) {
-        std::cout << "Can't open file!" << std::endl;
-        exit(1);
-    }
-
-    wf.write(
-        reinterpret_cast<const char *>(&room.bounds.left), 
-        sizeof (room.bounds.left)
-    );
-
-    wf.write(
-        reinterpret_cast<const char *>(&room.bounds.top), 
-        sizeof (room.bounds.top)
-    );
-
-    wf.write(
-        reinterpret_cast<const char *>(&room.bounds.width), 
-        sizeof (room.bounds.width)
-    );
-
-    wf.write(
-        reinterpret_cast<const char *>(&room.bounds.height), 
-        sizeof (room.bounds.height)
-    );
-
-    int room_tile_count = room.tiles->size();
-    wf.write(reinterpret_cast<const char *>(&room_tile_count), sizeof (room_tile_count));
-
-    for(int i = 0; i < room_tile_count; i++) {
-        wf.write(
-            reinterpret_cast<const char *>(&(*room.tiles)[i].rotation), 
-            sizeof ((*room.tiles)[i].rotation)
-        );
-
-        wf.write(
-            reinterpret_cast<const char *>(&(*room.tiles)[i].tile_map_index), 
-            sizeof ((*room.tiles)[i].tile_map_index)
-        );
-
-        wf.write(
-            reinterpret_cast<const char *>(&(*room.tiles)[i].x), 
-            sizeof ((*room.tiles)[i].x)
-        );
-
-        wf.write(
-            reinterpret_cast<const char *>(&(*room.tiles)[i].y), 
-            sizeof ((*room.tiles)[i].y)
-        );
-    }
 }

--- a/src/Room.cpp
+++ b/src/Room.cpp
@@ -78,8 +78,8 @@ Room::~Room() {
     delete tiles;
 }
 
-void DrawRoom(sf::RenderTarget& target, Room& room, TileMap& tile_map) {
-    for(Tile tile : *room.tiles) {
+void Room::DrawRoom(sf::RenderTarget& target, TileMap& tile_map) {
+    for(Tile tile : *tiles) {
         sf::Sprite sprite_to_draw((*tile_map.tiles)[tile.tile_map_index]);
         sprite_to_draw.setRotation(tile.rotation);
         int half_tile_size = tile_map.size * tile_map.scale / 2;
@@ -92,3 +92,56 @@ void DrawRoom(sf::RenderTarget& target, Room& room, TileMap& tile_map) {
     }
 }
 
+void Room::WriteRoomToFile(std::string file_name) {
+    std::ofstream wf(file_name, std::ios::out | std::ios::binary);
+
+    if(!wf) {
+        std::cout << "Can't open file!" << std::endl;
+        exit(1);
+    }
+
+    wf.write(
+        reinterpret_cast<const char *>(&bounds.left), 
+        sizeof (bounds.left)
+    );
+
+    wf.write(
+        reinterpret_cast<const char *>(&bounds.top), 
+        sizeof (bounds.top)
+    );
+
+    wf.write(
+        reinterpret_cast<const char *>(&bounds.width), 
+        sizeof (bounds.width)
+    );
+
+    wf.write(
+        reinterpret_cast<const char *>(&bounds.height), 
+        sizeof (bounds.height)
+    );
+
+    int room_tile_count = tiles->size();
+    wf.write(reinterpret_cast<const char *>(&room_tile_count), sizeof (room_tile_count));
+
+    for(int i = 0; i < room_tile_count; i++) {
+        wf.write(
+            reinterpret_cast<const char *>(&(*tiles)[i].rotation), 
+            sizeof ((*tiles)[i].rotation)
+        );
+
+        wf.write(
+            reinterpret_cast<const char *>(&(*tiles)[i].tile_map_index), 
+            sizeof ((*tiles)[i].tile_map_index)
+        );
+
+        wf.write(
+            reinterpret_cast<const char *>(&(*tiles)[i].x), 
+            sizeof ((*tiles)[i].x)
+        );
+
+        wf.write(
+            reinterpret_cast<const char *>(&(*tiles)[i].y), 
+            sizeof ((*tiles)[i].y)
+        );
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
             }
 
             if (ENABLE_EDITOR) {
-                UpdateEditor(editor, event, room, sf::Mouse::getPosition(window));
+                editor.UpdateEditor(event, room, sf::Mouse::getPosition(window));
             } 
          
             if (event.type == sf::Event::Closed)
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
         window.clear();
 
         if (ENABLE_EDITOR) {
-            DrawEditor(window, editor, room);
+            editor.DrawEditor(window, room);
         } else {
             DrawRoom(window, room, tile_map);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
         if (ENABLE_EDITOR) {
             editor.DrawEditor(window, room);
         } else {
-            DrawRoom(window, room, tile_map);
+            room.DrawRoom(window, tile_map);
         }
         window.display();
     }


### PR DESCRIPTION
This covers moving the `struct`s to `class`es, where appropriate.

I've left both `Room` and `Tile` out of this, as `Tile` has no logic (hence all the members need to `public`) and similarly, all of `Room`'s members are accessed directly, so they would need to be marked `public` also, which kind of defeats the idea of making it a class.

Broken up into commits covering the migration of free functions to member methods, and the actual change from class to struct.
