### PR TITLE
Add `TileMap::tileSize` method

### DIFF
--- a/headers/TileMap.h
+++ b/headers/TileMap.h
@@ -11,6 +11,8 @@ struct TileMap {
 
 	TileMap(std::string, int, int, int, int);
 	~TileMap();
+
+	int tileSize();
 };
 
 struct Tile {

--- a/src/Editor.cpp
+++ b/src/Editor.cpp
@@ -4,15 +4,10 @@
 
 Editor::Editor(TileMap &tile_map, int window_height, int window_width) {
     int offset = 20;
-    int left_toolbar_width = offset * 2 + (tile_map.scale * tile_map.size);
+    int left_toolbar_width = offset * 2 + tile_map.tileSize();
 
     sf::RectangleShape* selection = new sf::RectangleShape();
-    selection->setSize(
-            sf::Vector2f(
-                tile_map.size * tile_map.scale, 
-                tile_map.size * tile_map.scale
-                )
-            );
+    selection->setSize(sf::Vector2f(tile_map.tileSize(), tile_map.tileSize()));
     selection->setOutlineColor(sf::Color::Blue);
     selection->setOutlineThickness(2);
     selection->setFillColor(sf::Color::Transparent);
@@ -20,7 +15,7 @@ Editor::Editor(TileMap &tile_map, int window_height, int window_width) {
 
     this->selection_rectangle = selection;
     this->tiles = new std::vector<sf::Sprite>(*tile_map.tiles);
-    int total_height = (this->tiles->size() * (tile_map.scale * tile_map.size + offset)) + offset;
+    int total_height = (this->tiles->size() * (tile_map.tileSize() + offset)) + offset;
     sf::RectangleShape* background = new sf::RectangleShape(sf::Vector2f(left_toolbar_width, total_height));
     background->setFillColor(sf::Color(60,60,60, 255));
     this->background = background;

--- a/src/Room.cpp
+++ b/src/Room.cpp
@@ -82,10 +82,10 @@ void DrawRoom(sf::RenderTarget& target, Room& room, TileMap& tile_map) {
     for(Tile tile : *room.tiles) {
         sf::Sprite sprite_to_draw((*tile_map.tiles)[tile.tile_map_index]);
         sprite_to_draw.setRotation(tile.rotation);
-        int half_tile_size = tile_map.size * tile_map.scale / 2;
+        int half_tile_size = tile_map.tileSize() / 2;
         sprite_to_draw.setPosition(
-            (tile.x * tile_map.size * tile_map.scale) + half_tile_size,
-            (tile.y * tile_map.size * tile_map.scale) + half_tile_size
+            (tile.x * tile_map.tileSize()) + half_tile_size,
+            (tile.y * tile_map.tileSize()) + half_tile_size
         );
         sprite_to_draw.setOrigin(tile_map.size / 2, tile_map.size / 2);
         target.draw(sprite_to_draw);

--- a/src/TileMap.cpp
+++ b/src/TileMap.cpp
@@ -39,3 +39,7 @@ TileMap::TileMap (std::string texture_path, int scale, int size, int cols, int r
 TileMap::~TileMap() {
 	delete texture;
 }
+
+int TileMap::tileSize() {
+  return scale * size;
+}


### PR DESCRIPTION
As the `scale` and `size` members of `TileMap` are very often
multiplied together in use, make a helper method to return that