### PR TITLE
Move `Room` and `TileMap` to references

### DIFF
--- a/headers/RoomScene.h
+++ b/headers/RoomScene.h
@@ -23,7 +23,7 @@ class RoomScene {
     // The offset defines gaps between the tiles on the left hand tile editor
     int offset;
 
-    TileMap* tile_map;
+    TileMap &tile_map;
 
     // The currently selected tile index. This is the index for the tiles vector
     int selected_tile_index;
@@ -43,11 +43,11 @@ class RoomScene {
 
     sf::RenderTexture* room_render_texture;
 
-    Room *room;
+    Room &room;
 
     bool editor_enabled;
 public:
-    RoomScene(TileMap &, int, int, Room* room);
+    RoomScene(TileMap &, int, int, Room &);
     ~RoomScene();
     void Draw(sf::RenderTarget &);
     void Update(const sf::Event &, const sf::Vector2i);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
     
     Room room = argc == 2 ? Room(argv[1]) : Room(20, 20, window_height, window_width);
 
-    RoomScene room_scene(tile_map, window_height, window_width, &room);
+    RoomScene room_scene(tile_map, window_height, window_width, room);
 
 
     while (window.isOpen())


### PR DESCRIPTION
Given that both the `Room` and `TileMap` instances will outlive
the `RoomScene` instance, these can be moved to references within
the `RoomScene` instance, which should perform as well as being
stored as pointers