### PR TITLE
Initialise variables directly

### DIFF
--- a/src/RoomScene.cpp
+++ b/src/RoomScene.cpp
@@ -89,7 +89,7 @@ void RoomScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_
             sf::Vector2i(event.mouseButton.x, event.mouseButton.y)
         );
         
-        sf::IntRect pixel_bounds = sf::IntRect(
+        sf::IntRect pixel_bounds(
             0, 
             0, 
             this->room.bounds.width * tile_map.size * tile_map.scale,
@@ -103,7 +103,7 @@ void RoomScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_
 
 
             for (auto it = this->room.tiles->begin(); it != this->room.tiles->end(); ) {
-                sf::FloatRect current_tile_bounds = sf::FloatRect(
+                sf::FloatRect current_tile_bounds(
                     it->x * (tile_map.size * tile_map.scale),
                     it->y * (tile_map.size * tile_map.scale),
                     tile_map.size * tile_map.scale,
@@ -163,7 +163,7 @@ void RoomScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_
         current_rotation += 90;
     }
 
-    sf::Vector2i mouse_delta = sf::Vector2i(
+    sf::Vector2i mouse_delta(
         current_mouse_position.x - last_mouse_position.x, 
         current_mouse_position.y - last_mouse_position.y
     );

--- a/src/TileMap.cpp
+++ b/src/TileMap.cpp
@@ -1,7 +1,7 @@
 #include "TileMap.h"
 
 sf::Sprite CreateTileSprite(int tile_map_x, int tile_map_y, int scale, int size, sf::Texture& texture) {
-	sf::Sprite sprite = sf::Sprite();
+	sf::Sprite sprite;
 	sprite.setTextureRect(
 		sf::IntRect(
 			size * tile_map_x, 


### PR DESCRIPTION
Mainly an aesthetic change, as the compiler is clever enough to
collapse them already, but move all initial assignments to direct
initialisations, e.g.:

  foo f = foo(42);

becomes:

  foo f(42);