### PR TITLE
Remove explicit default initialisation of value type

### DIFF
--- a/src/RoomScene.cpp
+++ b/src/RoomScene.cpp
@@ -30,7 +30,6 @@ RoomScene::RoomScene(TileMap &tile_map, int window_height, int window_width, Roo
 
     current_mouse_grid_position = new sf::Vector2i();
     panning = false;
-    last_mouse_position = sf::Vector2i();
     current_rotation = 0;
 }
 


### PR DESCRIPTION
In the constructor for `RoomScene`, remove the default
initialisation of `last_mouse_position` as this will be done by
the compiler already