### PR TITLE
Memleak

### DIFF
--- a/src/RoomScene.cpp
+++ b/src/RoomScene.cpp
@@ -173,6 +173,7 @@ void RoomScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_
     if (event.type == sf::Event::Resized) {
         std::cout << event.size.width << std::endl;
         room_view->setSize(event.size.width, event.size.height);
+        delete room_render_texture;
         room_render_texture = new sf::RenderTexture();
         room_render_texture->create(event.size.width, event.size.height); 
     }

--- a/src/RoomScene.cpp
+++ b/src/RoomScene.cpp
@@ -35,13 +35,14 @@ RoomScene::RoomScene(TileMap &tile_map, int window_height, int window_width, Roo
 }
 
 RoomScene::~RoomScene() {
-    delete selection_rectangle;
     delete background;
-    delete tiles;
-    delete tile_palette_view;
     delete current_mouse_grid_position;
     delete room_render_texture;
     delete room_view;
+    delete selection_rectangle;
+    delete tile_palette_render_texture;
+    delete tile_palette_view;
+    delete tiles;
 }
 
 void RoomScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_position) {

--- a/src/TileMap.cpp
+++ b/src/TileMap.cpp
@@ -38,6 +38,7 @@ TileMap::TileMap (std::string texture_path, int scale, int size, int cols, int r
 
 TileMap::~TileMap() {
 	delete texture;
+	delete tiles;
 }
 
 int TileMap::tileSize() {


### PR DESCRIPTION
Some memory management cleanup based on the output of `valgrind`, exitting normally pretty much immediately after the content is drawn.

The lion's share was the repeated reallocation in `RoomScene::Update` when the window is resized (seems to happen about 3 times during initialisation here).