### PR TITLE
Use convenience constructors where possible

### DIFF
--- a/src/RoomScene.cpp
+++ b/src/RoomScene.cpp
@@ -8,8 +8,10 @@ RoomScene::RoomScene(SpriteSheet &tile_map, int window_height, int window_width,
     room(room), selected_tile_index(0), tile_map(tile_map), player(player) {
     int left_toolbar_width = offset * 2 + tile_map.SpriteSize();
 
-    selection_rectangle = new sf::RectangleShape();
-    selection_rectangle->setSize(sf::Vector2f(tile_map.SpriteSize(), tile_map.SpriteSize()));
+    selection_rectangle = new sf::RectangleShape(sf::Vector2f(
+        tile_map.SpriteSize(),
+        tile_map.SpriteSize()
+    ));
     selection_rectangle->setOutlineColor(sf::Color::Blue);
     selection_rectangle->setOutlineThickness(2);
     selection_rectangle->setFillColor(sf::Color::Transparent);

--- a/src/SpriteSheet.cpp
+++ b/src/SpriteSheet.cpp
@@ -23,8 +23,8 @@ SpriteSheet::~SpriteSheet() {
 }
 
 sf::Sprite SpriteSheet::CreateTileSprite(int tile_map_x, int tile_map_y, int scale, int size) {
-	sf::Sprite sprite;
-	sprite.setTextureRect(
+	sf::Sprite sprite(
+		texture,
 		sf::IntRect(
 			size * tile_map_x, 
 			size * tile_map_y, 
@@ -33,7 +33,6 @@ sf::Sprite SpriteSheet::CreateTileSprite(int tile_map_x, int tile_map_y, int sca
 		)
 	);
 
-	sprite.setTexture(texture);
 	sprite.setScale(scale, scale);
 	return sprite;
 }


### PR DESCRIPTION
When constructing instances of `sf::RectangleShape` and
`sf::Sprite`, if we are immediately update members that can be
passed in via a constructor, use that constructor instead