### PR TITLE
Add `Entity::Reset` to reset the movement vector

### DIFF
--- a/headers/Entity.h
+++ b/headers/Entity.h
@@ -21,6 +21,7 @@ public:
     sf::Vector2f getTransform();
     void Update(const sf::Event &);
     void Draw(sf::RenderTarget &);
+    void Reset();
 };
 
 

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -85,3 +85,8 @@ void Entity::Draw(sf::RenderTarget &target) {
 sf::Vector2f Entity::getTransform() {
     return transform;
 }
+
+void Entity::Reset() {
+    controller.x = 0;
+    controller.y = 0;
+}

--- a/src/RoomScene.cpp
+++ b/src/RoomScene.cpp
@@ -48,6 +48,7 @@ RoomScene::~RoomScene() {
 void RoomScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_position) {
     if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::E) {
         editor_enabled = !editor_enabled;
+        player.Reset();
     }
 
     if (!editor_enabled) {


### PR DESCRIPTION
To ensure that the player doesn't keep moving when editor has been
toggled, reset the movement vector via a `Reset` method on
`Entity`

This should take care of the situation where, in preview mode, while holding down a direction you can press `E` to get back into edit mode and the player sprite will continue moving.