### PR TITLE
Clean up member variable initialisation

### DIFF
--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -30,7 +30,6 @@ HouseScene::HouseScene(SpriteSheet &tile_map, int window_height, int window_widt
     house_view = new sf::View(sf::FloatRect(0, 0, window_height, window_height));
 
     current_mouse_grid_position = new sf::Vector2i();
-    last_mouse_position = sf::Vector2i();
 
 }
 

--- a/src/SpriteSheet.cpp
+++ b/src/SpriteSheet.cpp
@@ -8,14 +8,12 @@ SpriteSheet::SpriteSheet (std::string texture_path, int scale, int size, int col
 		exit(1);
 	}
 
-	std::vector<sf::Sprite>* tile_sprites = new std::vector<sf::Sprite>();
+	tiles = new std::vector<sf::Sprite>();
 	for(int y = 0; y < cols; y++) {
 		for(int x = 0; x < rows; x++) {
-			tile_sprites->push_back(CreateTileSprite(x, y, scale, size));
+			tiles->push_back(CreateTileSprite(x, y, scale, size));
 		}
 	}
-
-	this->tiles = tile_sprites;
 };
 
 SpriteSheet::~SpriteSheet() {


### PR DESCRIPTION
In `HouseScene::HouseScene(...)` remove unneeded default
construction of `last_mouse_position` and in
`SpriteSheet::SpriteSheet(...)` construct `tiles` directly and
push back each of the created sprites into it