### PR TITLE
Sanitizer fixups

### DIFF
--- a/headers/TilePaletteView.h
+++ b/headers/TilePaletteView.h
@@ -35,6 +35,7 @@ class TilePaletteView {
 
 public:
     TilePaletteView(SpriteSheet&, int);
+    ~TilePaletteView();
     sf::RectangleShape* GetBackground();
     void Draw(sf::RenderTarget &);
     void Update(const sf::Event &, const sf::Vector2i);

--- a/src/TilePaletteView.cpp
+++ b/src/TilePaletteView.cpp
@@ -34,6 +34,13 @@ TilePaletteView::TilePaletteView(
     tile_palette_view = new sf::View(sf::FloatRect(0, 0, left_toolbar_width, window_height));
 }
 
+TilePaletteView::~TilePaletteView() {
+    delete background;
+    delete selection_rectangle;
+    delete tile_palette_render_texture;
+    delete tile_palette_view;
+}
+
 sf::Sprite TilePaletteView::CreateIconSprite(int sprite_size, sf::Color color) {
     auto icon_sprite_render_texture = new sf::RenderTexture(); 
     icon_sprite_render_texture->create(sprite_size, sprite_size);

--- a/src/TilePaletteView.cpp
+++ b/src/TilePaletteView.cpp
@@ -3,7 +3,7 @@
 TilePaletteView::TilePaletteView(
     SpriteSheet &tile_map, 
     int window_height
-) : tile_map(tile_map), offset(20) {
+) : tile_map(tile_map), offset(20), selected_tile_index(0) {
 
     selection_rectangle = new sf::RectangleShape(sf::Vector2f(
         tile_map.SpriteSize(),


### PR DESCRIPTION
A couple of fixes that came up after running with the address sanitiser.

The first is to ensure that `TilePaletteView::selected_tile_index` is 0, which also ensures that the selection rectangle sits over the first palette tile item properly from the get go.

The second is to add a destructor on `TilePaletteView`, to ensure all the `new`ed up pointers are `delete`d