### PR TITLE
Sf convenience methods

### DIFF
--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -60,8 +60,8 @@ void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse
         );
 
 
-        if (pixel_bounds.contains(sf::Vector2i(event_target_coords.x, event_target_coords.y)) && 
-            !tile_palette_view.GetBackground()->getGlobalBounds().contains(sf::Vector2f(event.mouseButton.x, event.mouseButton.y))
+        if (pixel_bounds.contains(event_target_coords.x, event_target_coords.y) && 
+            !tile_palette_view.GetBackground()->getGlobalBounds().contains(event.mouseButton.x, event.mouseButton.y)
         ) {
             auto sprite_size = tile_map.SpriteSize();
             auto found = std::find_if(house.tiles->begin(), house.tiles->end(), [event_target_coords, sprite_size](const auto &t) {

--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -111,7 +111,7 @@ void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse
     last_mouse_position = current_mouse_position;
 
     if (panning) {
-        house_view->move(sf::Vector2f(mouse_delta.x * -1, mouse_delta.y * -1));
+        house_view->move(mouse_delta.x * -1, mouse_delta.y * -1);
     }
 
     if (event.type == sf::Event::Resized) {

--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -166,7 +166,7 @@ void HouseScene::Draw(sf::RenderTarget& target) {
 
         // Draw Selected Tile
         auto selected_tile_sprite = tile_palette_view.GetSelectedTileSprite();
-        selected_tile_sprite.setScale(sf::Vector2f(tile_map.scale, tile_map.scale));
+        selected_tile_sprite.setScale(tile_map.scale, tile_map.scale);
         int half_tile_size = tile_map.SpriteSize() / 2;
         selected_tile_sprite.setPosition(
             (current_mouse_grid_position->x * tile_map.SpriteSize()) + half_tile_size,

--- a/src/TilePaletteView.cpp
+++ b/src/TilePaletteView.cpp
@@ -87,11 +87,11 @@ void TilePaletteView::Update(const sf::Event & event, const sf::Vector2i) {
         int lower_scroll_center = background->getSize().y - upper_scroll_center;
 
         if (event.mouseWheel.delta < 0 && tile_palette_view->getCenter().y > upper_scroll_center) {
-            tile_palette_view->move(sf::Vector2f(0, 100 * event.mouseWheel.delta));
+            tile_palette_view->move(0, 100 * event.mouseWheel.delta);
         }
 
         if (event.mouseWheel.delta > 0 && tile_palette_view->getCenter().y < lower_scroll_center) {
-            tile_palette_view->move(sf::Vector2f(0, 100 * event.mouseWheel.delta));
+            tile_palette_view->move(0, 100 * event.mouseWheel.delta);
         }
     }
 


### PR DESCRIPTION
Use some SFML method overloads that accept individual values instead of those that accept composite types (Vector2 etc) to avoid the assignment and clean up the code