### PR TITLE
Use `window_width` when constructing `house_view`

### DIFF
--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -11,7 +11,7 @@ HouseScene::HouseScene(
 ) : current_rotation(0), 
     editor_enabled(true), 
     house(house), 
-    house_view(sf::FloatRect(0, 0, window_height, window_height)),
+    house_view(sf::FloatRect(0, 0, window_width, window_height)),
     panning(false),
     player(player), 
     tile_map(tile_map), 


### PR DESCRIPTION
When initialising `house_view` as part of the `HouseScene`
constructor, use the `window_width` parameter instead of
accidentally using the `window_height` parameter twice

Fixes #34