### PR TITLE
Map overhaul v2

### DIFF
--- a/headers/Entity.h
+++ b/headers/Entity.h
@@ -4,7 +4,7 @@
 #include <SFML/Graphics.hpp>
 #include "Animation.h"
 
-enum EntityType { PlayerEntity, GhostEntity, DoorEntity };
+enum EntityType { GhostEntity = 0, DoorEntity = 1, PlayerEntity = 2, };
 
 class Entity {
     float acceleration;
@@ -18,12 +18,15 @@ class Entity {
     EntityType type;
 
 public:
-    Entity(EntityType, float, float);
+    Entity(EntityType, float, float, float, float);
     Entity(EntityType, float, float, std::unordered_map<std::string, Animation>&);
     const sf::Vector2f &getTransform() const;
     void Update(const sf::Event &);
     void Draw(sf::RenderTarget &);
     void Reset();
+    sf::Vector2f GetTransform() const; 
+    int GetTileMapIndex() const; 
+    int GetRotation() const; 
 };
 
 

--- a/headers/Entity.h
+++ b/headers/Entity.h
@@ -24,14 +24,13 @@ class Entity {
 public:
     Entity(EntityType, float, float, float, float);
     Entity(EntityType, float, float, std::unordered_map<std::string, Animation>&);
-    const sf::Vector2f &getTransform() const;
     void Update(const sf::Event &);
     void Draw(sf::RenderTarget &);
     void Reset();
-    sf::Vector2f GetTransform() const; 
-    int GetTileMapIndex() const; 
-    int GetRotation() const; 
-    EntityType GetEntityType () const; 
+    const sf::Vector2f& GetTransform() const; 
+    const int GetTileMapIndex() const; 
+    const int GetRotation() const; 
+    const EntityType GetEntityType () const; 
 };
 
 

--- a/headers/Entity.h
+++ b/headers/Entity.h
@@ -4,7 +4,11 @@
 #include <SFML/Graphics.hpp>
 #include "Animation.h"
 
-enum EntityType { GhostEntity = 0, DoorEntity = 1, PlayerEntity = 2, };
+enum class EntityType { 
+    GhostEntity = 0, 
+    DoorEntity = 1, 
+    PlayerEntity = 2
+};
 
 class Entity {
     float acceleration;
@@ -27,6 +31,7 @@ public:
     sf::Vector2f GetTransform() const; 
     int GetTileMapIndex() const; 
     int GetRotation() const; 
+    EntityType GetEntityType () const; 
 };
 
 

--- a/headers/HouseScene.h
+++ b/headers/HouseScene.h
@@ -20,11 +20,12 @@ class HouseScene {
     bool panning;
     Entity &player;
     SpriteSheet &tile_map;
+    SpriteSheet &entity_map;
     TilePaletteView tile_palette_view;
     int current_selected_tile_layer;
 
 public:
-    HouseScene(SpriteSheet &, int, int, Map &, Entity &);
+    HouseScene(SpriteSheet&, SpriteSheet&, int, int, Map &, Entity &);
     ~HouseScene();
     void Draw(sf::RenderTarget &);
     void Update(const sf::Event &, const sf::Vector2i);

--- a/headers/HouseScene.h
+++ b/headers/HouseScene.h
@@ -10,28 +10,18 @@
  * An editor contains all data required to add, remove and edit tiles on a given map
  */
 class HouseScene {
-    // The current mouse house grid pos
     sf::Vector2i current_mouse_grid_position;
-
     float current_rotation;
-
     bool editor_enabled;
-
     Map &map;
-
     sf::RenderTexture house_render_texture;
-
     sf::View house_view;
-
     sf::Vector2i last_mouse_position;
-
     bool panning;
-    
     Entity &player;
-
     SpriteSheet &tile_map;
-
     TilePaletteView tile_palette_view;
+    int current_selected_tile_layer;
 
 public:
     HouseScene(SpriteSheet &, int, int, Map &, Entity &);

--- a/headers/Map.h
+++ b/headers/Map.h
@@ -1,20 +1,35 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
-#include "Tile.h"
+#include "Entity.h"
 #include "SpriteSheet.h"
 
+struct Tile {
+    int x;
+    int y;
+    int rotation;
+    int tile_map_index;
+};
+
+struct TileLayer {
+    int layer_index;
+    std::vector<Tile> tiles;
+};
+
 // A map holds all data for a given tile layout within the game.
-struct Map {
+class Map {
+    int map_file_version;
     sf::IntRect bounds;
+    std::vector<TileLayer> tile_layers;
+    std::vector<Entity> entity;
 
-	std::vector<Tile>* tiles;
-
+public:
 	Map(std::string);
 	Map(int, int, int, int);
-	~Map();
 
-	void Draw(sf::RenderTarget &, const SpriteSheet &) const;
 	void WriteToFile(std::string) const;
+    sf::IntRect GetBounds();
+    std::vector<TileLayer>& GetTileLayers();
+    void AddTile(int, Tile);
 };
 

--- a/headers/Map.h
+++ b/headers/Map.h
@@ -28,9 +28,9 @@ public:
 	Map(int, int, int, int);
 
 	void WriteToFile(std::string) const;
-    sf::IntRect GetBounds();
-    std::vector<TileLayer>& GetTileLayers();
-    std::vector<Entity>& GetEntities();
+    const sf::IntRect GetBounds() const;
+    const std::vector<TileLayer>& GetTileLayers() const;
+    const std::vector<Entity>& GetEntities() const;
     void AddTile(int, MapTile);
     void AddEntity(Entity);
 };

--- a/headers/Map.h
+++ b/headers/Map.h
@@ -4,7 +4,7 @@
 #include "Entity.h"
 #include "SpriteSheet.h"
 
-struct Tile {
+struct MapTile {
     int x;
     int y;
     int rotation;
@@ -13,7 +13,7 @@ struct Tile {
 
 struct TileLayer {
     int layer_index;
-    std::vector<Tile> tiles;
+    std::vector<MapTile> tiles;
 };
 
 // A map holds all data for a given tile layout within the game.
@@ -21,7 +21,7 @@ class Map {
     int map_file_version;
     sf::IntRect bounds;
     std::vector<TileLayer> tile_layers;
-    std::vector<Entity> entity;
+    std::vector<Entity> entities;
 
 public:
 	Map(std::string);
@@ -30,6 +30,8 @@ public:
 	void WriteToFile(std::string) const;
     sf::IntRect GetBounds();
     std::vector<TileLayer>& GetTileLayers();
-    void AddTile(int, Tile);
+    std::vector<Entity>& GetEntities();
+    void AddTile(int, MapTile);
+    void AddEntity(Entity);
 };
 

--- a/headers/SpriteSheet.h
+++ b/headers/SpriteSheet.h
@@ -5,14 +5,20 @@
 
 class SpriteSheet {
     sf::Sprite CreateTileSprite(int, int, int, int);
-
-public:
+	std::vector<sf::Sprite> sprites;
 	int scale;
 	int size;
 	sf::Texture texture;
-	std::vector<sf::Sprite>* tiles;
+    sf::RenderTexture icon_sprite_render_texture;
+    sf::Sprite CreateIconSprite(sf::Color, int);
+public:
 	SpriteSheet(std::string, int, int, int, int);
-	~SpriteSheet();
-	int SpriteSize() const;
+	SpriteSheet(int, int);
+	int GetSpriteSize() const;
+    std::vector<sf::Sprite> GetSprites();
+    const sf::Texture& GetTexture();
+    int GetScale() const;
+    int GetSize() const;
+    
 };
 

--- a/headers/SpriteSheet.h
+++ b/headers/SpriteSheet.h
@@ -14,11 +14,10 @@ class SpriteSheet {
 public:
 	SpriteSheet(std::string, int, int, int, int);
 	SpriteSheet(int, int);
-	int GetSpriteSize() const;
-    std::vector<sf::Sprite> GetSprites();
-    const sf::Texture& GetTexture();
-    int GetScale() const;
-    int GetSize() const;
-    
+	const int GetSpriteSize() const;
+    const std::vector<sf::Sprite>& GetSprites() const;
+    const sf::Texture& GetTexture() const;
+    const int GetScale() const;
+    const int GetSize() const;
 };
 

--- a/headers/Tile.h
+++ b/headers/Tile.h
@@ -1,8 +1,2 @@
 #pragma once
 
-struct Tile {
-    int x;
-    int y;
-    int rotation;
-    int tile_map_index;
-};

--- a/headers/TilePaletteView.h
+++ b/headers/TilePaletteView.h
@@ -10,7 +10,6 @@ class TilePaletteView {
     // The background shape for the tile toolbar editor
     sf::RectangleShape background;
 
-    sf::RenderTexture icon_sprite_render_texture;
 
     // The offset defines gaps between the tiles on the left hand tile editor
     int offset;
@@ -22,25 +21,22 @@ class TilePaletteView {
     sf::RectangleShape selection_rectangle;
 
     SpriteSheet &tile_map;
+
+    SpriteSheet &entity_map;
     
     sf::RenderTexture tile_palette_render_texture;
 
     // The view for the current tile palette that appears on the left side of the window
     sf::View tile_palette_view;
 
-    // A list of vector of spirte tiles for rendering in the sidebar of the editor
-    // std::vector<sf::Sprite>* tiles;
     std::vector<TilePaletteTile> tiles;
 
-    sf::Sprite CreateIconSprite(int, sf::Color, int);
-
 public:
-    TilePaletteView(SpriteSheet&, int);
+    TilePaletteView(SpriteSheet&, SpriteSheet&, int);
     ~TilePaletteView();
     const sf::RectangleShape &GetBackground() const;
     void Draw(sf::RenderTarget &);
     void Update(const sf::Event &, const sf::Vector2i);
     int GetSelectedTileIndex() const;
-    const sf::Sprite& GetSelectedTileSprite() const;
-
+    const TilePaletteTile& GetSelectedTile() const;
 };

--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -7,8 +7,8 @@ Animation::Animation(SpriteSheet & sprite_sheet, std::vector<AnimationFrame> ani
         frame_width(frame_width), 
         speed(speed),
         sprite_sheet(sprite_sheet) {
-    sprite.setTexture(sprite_sheet.texture);
-    sprite.setScale(sprite_sheet.scale, sprite_sheet.scale);
+    sprite.setTexture(sprite_sheet.GetTexture());
+    sprite.setScale(sprite_sheet.GetScale(), sprite_sheet.GetScale());
     sprite.setOrigin(frame_width / 2, frame_height / 2);
 }
 

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -99,19 +99,14 @@ sf::Vector2f Entity::GetTransform() const {
 }
 
 int Entity::GetTileMapIndex() const {
-    /*
-    if (type == DoorEntity) {
-        return 1;
-    } else if (type == PlayerEntity) {
-        return 0;
-    } else {
-        std::cout << "Unknown Entity Type : " << type << std::endl;
-        exit(1);
-    }
-    */
-    return type;
+    typedef std::underlying_type<EntityType>::type utype;
+    return static_cast<utype>(type);
 }
 
 int Entity::GetRotation() const {
     return 0;
+}
+
+EntityType Entity::GetEntityType() const {
+    return type;
 }

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -85,28 +85,24 @@ void Entity::Draw(sf::RenderTarget &target) {
 }
 
 
-const sf::Vector2f &Entity::getTransform() const {
-    return transform;
-}
-
 void Entity::Reset() {
     controller.x = 0;
     controller.y = 0;
 }
 
-sf::Vector2f Entity::GetTransform() const {
+const sf::Vector2f& Entity::GetTransform() const {
     return transform;
 }
 
-int Entity::GetTileMapIndex() const {
+const int Entity::GetTileMapIndex() const {
     typedef std::underlying_type<EntityType>::type utype;
     return static_cast<utype>(type);
 }
 
-int Entity::GetRotation() const {
+const int Entity::GetRotation() const {
     return 0;
 }
 
-EntityType Entity::GetEntityType() const {
+const EntityType Entity::GetEntityType() const {
     return type;
 }

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -1,10 +1,11 @@
 #include "Entity.h"
 
-Entity::Entity(EntityType type, float speed, float acceleration) : 
+Entity::Entity(EntityType type, float speed, float acceleration, float x, float y) : 
     acceleration(acceleration), 
     animations(),
     facing_left(true),
     speed(speed), 
+    transform(sf::Vector2f(x, y)),
     type(type) {}
 
 Entity::Entity(
@@ -91,4 +92,26 @@ const sf::Vector2f &Entity::getTransform() const {
 void Entity::Reset() {
     controller.x = 0;
     controller.y = 0;
+}
+
+sf::Vector2f Entity::GetTransform() const {
+    return transform;
+}
+
+int Entity::GetTileMapIndex() const {
+    /*
+    if (type == DoorEntity) {
+        return 1;
+    } else if (type == PlayerEntity) {
+        return 0;
+    } else {
+        std::cout << "Unknown Entity Type : " << type << std::endl;
+        exit(1);
+    }
+    */
+    return type;
+}
+
+int Entity::GetRotation() const {
+    return 0;
 }

--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -4,6 +4,7 @@
 
 HouseScene::HouseScene(
         SpriteSheet &tile_map, 
+        SpriteSheet &entity_map, 
         int window_height, 
         int window_width, 
         Map &map, 
@@ -15,7 +16,8 @@ HouseScene::HouseScene(
     panning(false),
     player(player), 
     tile_map(tile_map), 
-    tile_palette_view(tile_map, window_height),
+    entity_map(entity_map), 
+    tile_palette_view(tile_map, entity_map, window_height),
     current_selected_tile_layer(0)
 {
     house_render_texture.create(window_width, window_height); 
@@ -41,8 +43,8 @@ void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse
             sf::Vector2i(current_mouse_position.x, current_mouse_position.y)
     );
 
-    current_mouse_grid_position.x = floor(current_target_coords.x / tile_map.SpriteSize());
-    current_mouse_grid_position.y = floor(current_target_coords.y / tile_map.SpriteSize());
+    current_mouse_grid_position.x = floor(current_target_coords.x / tile_map.GetSpriteSize());
+    current_mouse_grid_position.y = floor(current_target_coords.y / tile_map.GetSpriteSize());
      
     if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Left) {
         
@@ -53,24 +55,32 @@ void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse
         sf::IntRect pixel_bounds(
             0, 
             0,
-            map.GetBounds().width * tile_map.SpriteSize(),
-            map.GetBounds().height * tile_map.SpriteSize()
+            map.GetBounds().width * tile_map.GetSpriteSize(),
+            map.GetBounds().height * tile_map.GetSpriteSize()
         );
-
-
 
         if (pixel_bounds.contains(event_target_coords.x, event_target_coords.y) && 
             !tile_palette_view.GetBackground().getGlobalBounds().contains(event.mouseButton.x, event.mouseButton.y)
         ) {
-            map.AddTile(
-                current_selected_tile_layer, 
-                Tile { 
-                    (int)event_target_coords.x / tile_map.SpriteSize(),
-                    (int)event_target_coords.y / tile_map.SpriteSize(),
-                    (int)current_rotation,
-                    tile_palette_view.GetSelectedTileIndex()
-                }
-            );
+            auto x = (int)event_target_coords.x / tile_map.GetSpriteSize();
+            auto y = (int)event_target_coords.y / tile_map.GetSpriteSize();
+
+            if (tile_palette_view.GetSelectedTile().type == PaletteTile) {
+                map.AddTile(
+                    current_selected_tile_layer, 
+                    MapTile { 
+                        x,
+                        y,
+                        (int)current_rotation,
+                        tile_palette_view.GetSelectedTileIndex()
+                    }
+                );
+            } else if (tile_palette_view.GetSelectedTile().type == PaletteEntity){
+                map.AddEntity(Entity(tile_palette_view.GetSelectedTile().entity_type, 0, 0, x, y));
+            } else {
+                std::cout << "Map type not supported" << std::endl;
+                exit(1);
+            }
         }
     }
 
@@ -101,8 +111,6 @@ void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse
 
     if (event.type == sf::Event::Resized) {
         house_view.setSize(event.size.width, event.size.height);
-        //delete house_render_texture;
-        //house_render_texture = new sf::RenderTexture();
         house_render_texture.create(event.size.width, event.size.height); 
     }
  
@@ -140,17 +148,30 @@ void HouseScene::Draw(sf::RenderTarget& target) {
 
     for(const auto &tile_layer : map.GetTileLayers()) {
         for(const auto &tile : tile_layer.tiles) {
-            sf::Sprite sprite_to_draw((*tile_map.tiles)[tile.tile_map_index]);
+            sf::Sprite sprite_to_draw(tile_map.GetSprites()[tile.tile_map_index]);
             sprite_to_draw.setRotation(tile.rotation);
-            int half_tile_size = tile_map.SpriteSize() / 2;
+            int half_tile_size = tile_map.GetSpriteSize() / 2;
             sprite_to_draw.setPosition(
-                (tile.x * tile_map.SpriteSize()) + half_tile_size,
-                (tile.y * tile_map.SpriteSize()) + half_tile_size
+                (tile.x * tile_map.GetSpriteSize()) + half_tile_size,
+                (tile.y * tile_map.GetSpriteSize()) + half_tile_size
             );
-            sprite_to_draw.setOrigin(tile_map.size / 2, tile_map.size / 2);
+            sprite_to_draw.setOrigin(tile_map.GetSize() / 2, tile_map.GetSize() / 2);
             house_render_texture.draw(sprite_to_draw);
         }
     }
+
+    auto entities = map.GetEntities();
+    std::for_each(entities.begin(), entities.end(), [this](Entity &entity){
+        sf::Sprite sprite_to_draw(entity_map.GetSprites()[entity.GetTileMapIndex()]);
+        sprite_to_draw.setRotation(entity.GetRotation());
+        int half_tile_size = entity_map.GetSpriteSize() / 2;
+        sprite_to_draw.setPosition(
+            (entity.GetTransform().x * entity_map.GetSpriteSize()) + half_tile_size,
+            (entity.GetTransform().y * entity_map.GetSpriteSize()) + half_tile_size
+        );
+        sprite_to_draw.setOrigin(entity_map.GetSize() / 2, entity_map.GetSize() / 2);
+        house_render_texture.draw(sprite_to_draw);
+    });
 
     player.Draw(house_render_texture);
 
@@ -159,19 +180,18 @@ void HouseScene::Draw(sf::RenderTarget& target) {
             house_render_texture,
             map.GetBounds().height, 
             map.GetBounds().width, 
-            tile_map.SpriteSize()
+            tile_map.GetSpriteSize()
         );
 
         // Draw Selected Tile
-        auto selected_tile_sprite = tile_palette_view.GetSelectedTileSprite();
-        selected_tile_sprite.setScale(tile_map.scale, tile_map.scale);
-        int half_tile_size = tile_map.SpriteSize() / 2;
+        auto selected_tile_sprite = tile_palette_view.GetSelectedTile().icon;
+        int half_tile_size = tile_map.GetSpriteSize() / 2;
         selected_tile_sprite.setPosition(
-            (current_mouse_grid_position.x * tile_map.SpriteSize()) + half_tile_size,
-            (current_mouse_grid_position.y * tile_map.SpriteSize()) + half_tile_size
+            (current_mouse_grid_position.x * tile_map.GetSpriteSize()) + half_tile_size,
+            (current_mouse_grid_position.y * tile_map.GetSpriteSize()) + half_tile_size
         );
         selected_tile_sprite.setColor(sf::Color(255, 255, 255, 170));
-        selected_tile_sprite.setOrigin(tile_map.size / 2, tile_map.size / 2);
+        selected_tile_sprite.setOrigin(tile_map.GetSize() / 2, tile_map.GetSize() / 2);
         selected_tile_sprite.rotate(current_rotation);
 
         house_render_texture.draw(selected_tile_sprite);

--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -139,7 +139,7 @@ void DrawGrid(sf::RenderTarget &target, int grid_height, int grid_width, int siz
 
 void HouseScene::Draw(sf::RenderTarget& target) {
     if (!editor_enabled) {
-        house_view.setCenter(player.getTransform());
+        house_view.setCenter(player.GetTransform());
     }
 
     // Draw Room and Grid
@@ -161,7 +161,7 @@ void HouseScene::Draw(sf::RenderTarget& target) {
     }
 
     auto entities = map.GetEntities();
-    std::for_each(entities.begin(), entities.end(), [this](Entity &entity){
+    std::for_each(entities.begin(), entities.end(), [this](const auto &entity){
         sf::Sprite sprite_to_draw(entity_map.GetSprites()[entity.GetTileMapIndex()]);
         sprite_to_draw.setRotation(entity.GetRotation());
         int half_tile_size = entity_map.GetSpriteSize() / 2;

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -62,7 +62,7 @@ Map::Map(std::string file_name) {
     for(auto k = 0; k < entity_count; k++) {
         
         EntityType type;
-        rf.read(reinterpret_cast<char *>(&type), sizeof (int));
+        rf.read(reinterpret_cast<char *>(&type), sizeof (type));
 
         int x;
         rf.read(reinterpret_cast<char *>(&x), sizeof (x));
@@ -125,7 +125,6 @@ void Map::WriteToFile(std::string file_name) const {
     }
 
     int entity_size = entities.size();
-    std::cout << entity_size << std::endl;
     wf.write(reinterpret_cast<const char *>(&entity_size), sizeof (entity_size));
 
     std::for_each(entities.begin(), entities.end(), [&wf](Entity entity){
@@ -144,11 +143,11 @@ void Map::WriteToFile(std::string file_name) const {
 
 }
 
-sf::IntRect Map::GetBounds() {
+const sf::IntRect Map::GetBounds() const {
     return bounds;
 }
 
-std::vector<TileLayer>& Map::GetTileLayers() {
+const std::vector<TileLayer>& Map::GetTileLayers() const {
     return tile_layers;
 }
 
@@ -172,6 +171,6 @@ void Map::AddEntity(Entity entity) {
 }
 
 
-std::vector<Entity>& Map::GetEntities() {
+const std::vector<Entity>& Map::GetEntities() const {
     return entities;
 }

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -57,6 +57,21 @@ Map::Map(std::string file_name) {
         tile_layers.push_back(TileLayer{i, tiles});
     }
 
+    int entity_count;
+    rf.read(reinterpret_cast<char *>(&entity_count), sizeof(entity_count));
+    for(auto k = 0; k < entity_count; k++) {
+        
+        EntityType type;
+        rf.read(reinterpret_cast<char *>(&type), sizeof (int));
+
+        int x;
+        rf.read(reinterpret_cast<char *>(&x), sizeof (x));
+
+        int y;
+        rf.read(reinterpret_cast<char *>(&y), sizeof (y));
+
+        entities.push_back(Entity(type, 0, 0, x, y));
+    }
 }
 
 Map::Map(int map_height, int map_width, int window_width, int window_height)
@@ -73,25 +88,13 @@ void Map::WriteToFile(std::string file_name) const {
         exit(1);
     }
 
-    wf.write(
-        reinterpret_cast<const char *>(&bounds.left), 
-        sizeof (bounds.left)
-    );
+    wf.write(reinterpret_cast<const char *>(&bounds.left), sizeof (bounds.left));
+    wf.write(reinterpret_cast<const char *>(&bounds.top), sizeof (bounds.top));
+    wf.write(reinterpret_cast<const char *>(&bounds.width), sizeof (bounds.width));
+    wf.write(reinterpret_cast<const char *>(&bounds.height), sizeof (bounds.height));
 
-    wf.write(
-        reinterpret_cast<const char *>(&bounds.top), 
-        sizeof (bounds.top)
-    );
-
-    wf.write(
-        reinterpret_cast<const char *>(&bounds.width), 
-        sizeof (bounds.width)
-    );
-
-    wf.write(
-        reinterpret_cast<const char *>(&bounds.height), 
-        sizeof (bounds.height)
-    );
+    int size = tile_layers.size();
+    wf.write(reinterpret_cast<const char *>(&size), sizeof (size));
 
     for (const auto &tile_layer: tile_layers) {
         int room_tile_count = tile_layer.tiles.size();
@@ -120,6 +123,24 @@ void Map::WriteToFile(std::string file_name) const {
         }
 
     }
+
+    int entity_size = entities.size();
+    std::cout << entity_size << std::endl;
+    wf.write(reinterpret_cast<const char *>(&entity_size), sizeof (entity_size));
+
+    std::for_each(entities.begin(), entities.end(), [&wf](Entity entity){
+        EntityType type = entity.GetEntityType();
+        //typedef std::underlying_type<EntityType>::type utype;
+        //int i = static_cast<utype>(type);
+
+        wf.write(reinterpret_cast<const char *>(&type), sizeof (type));
+
+        int x = entity.GetTransform().x;
+        wf.write(reinterpret_cast<const char *>(&x), sizeof (x));
+
+        int y = entity.GetTransform().y;
+        wf.write(reinterpret_cast<const char *>(&y), sizeof (y));
+    });
 
 }
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -27,10 +27,10 @@ Map::Map(std::string file_name) {
             sizeof(room_tile_count)
         );
 
-        std::vector<Tile> tiles;
+        std::vector<MapTile> tiles;
 
         for(auto i = 0; i < room_tile_count; i++) {
-            Tile tile;
+            MapTile tile;
             rf.read(
                 reinterpret_cast<char *>(&tile.rotation), 
                 sizeof (tile.rotation)
@@ -62,7 +62,7 @@ Map::Map(std::string file_name) {
 Map::Map(int map_height, int map_width, int window_width, int window_height)
     : bounds(0, 0, map_width, map_height) {
 
-    tile_layers.push_back(TileLayer{0, std::vector<Tile>()});
+    tile_layers.push_back(TileLayer{0, std::vector<MapTile>()});
 }
 
 void Map::WriteToFile(std::string file_name) const {
@@ -131,7 +131,7 @@ std::vector<TileLayer>& Map::GetTileLayers() {
     return tile_layers;
 }
 
-void Map::AddTile(int index, Tile tile) {
+void Map::AddTile(int index, MapTile tile) {
     auto found = std::find_if(
         tile_layers[index].tiles.begin(), 
         tile_layers[index].tiles.end(), 
@@ -146,3 +146,11 @@ void Map::AddTile(int index, Tile tile) {
     tile_layers[index].tiles.push_back(tile);
 }
 
+void Map::AddEntity(Entity entity) {
+    entities.push_back(entity);
+}
+
+
+std::vector<Entity>& Map::GetEntities() {
+    return entities;
+}

--- a/src/SpriteSheet.cpp
+++ b/src/SpriteSheet.cpp
@@ -55,22 +55,22 @@ sf::Sprite SpriteSheet::CreateTileSprite(int tile_map_x, int tile_map_y, int sca
 	return sprite;
 }
 
-int SpriteSheet::GetSpriteSize() const {
+const int SpriteSheet::GetSpriteSize() const {
   return scale * size;
 }
 
-int SpriteSheet::GetScale() const {
+const int SpriteSheet::GetScale() const {
     return scale;
 }
 
-int SpriteSheet::GetSize() const {
+const int SpriteSheet::GetSize() const {
     return size;
 }
 
-const sf::Texture& SpriteSheet::GetTexture() {
+const sf::Texture& SpriteSheet::GetTexture() const {
     return texture;
 }
 
-std::vector<sf::Sprite> SpriteSheet::GetSprites() {
+const std::vector<sf::Sprite>& SpriteSheet::GetSprites() const {
     return sprites;
 }

--- a/src/SpriteSheet.cpp
+++ b/src/SpriteSheet.cpp
@@ -1,23 +1,43 @@
 #include "SpriteSheet.h"
 
-
+// For now we will assume that this is a constructor for a sprite sheet from a texture file
 SpriteSheet::SpriteSheet (std::string texture_path, int scale, int size, int cols, int rows)
-	: scale(scale), size(size), texture() {
+	:  sprites(), scale(scale), size(size), texture() {
 	if (!texture.loadFromFile(texture_path)) {
 		std::cout << "Can't laod file" << std::endl;
 		exit(1);
 	}
 
-	tiles = new std::vector<sf::Sprite>();
 	for(auto y = 0; y < cols; y++) {
 		for(auto x = 0; x < rows; x++) {
-			tiles->push_back(CreateTileSprite(x, y, scale, size));
+			sprites.push_back(CreateTileSprite(x, y, scale, size));
 		}
 	}
 };
 
-SpriteSheet::~SpriteSheet() {
-	delete tiles;
+// For now we will assume that this is a entity sprite sheet drawn with code
+SpriteSheet::SpriteSheet (int scale, int size) : sprites(), scale(scale), size(size), texture() {
+    icon_sprite_render_texture.create(size * 2, size);
+    auto door_palette_sprite_icon = CreateIconSprite(sf::Color::Red, 0);
+    sprites.push_back(door_palette_sprite_icon);
+
+    auto ghost_palette_sprite_icon = CreateIconSprite(sf::Color::Green, 1);
+    sprites.push_back(ghost_palette_sprite_icon);
+};
+
+sf::Sprite SpriteSheet::CreateIconSprite(sf::Color color, int render_offset) {
+    auto icon_rect = sf::RectangleShape(sf::Vector2f(size, size));
+    icon_rect.setFillColor(color);
+    icon_rect.setPosition(size * render_offset, 0);
+    icon_sprite_render_texture.draw(icon_rect);
+    icon_sprite_render_texture.display();
+
+    auto sprite = sf::Sprite(
+        icon_sprite_render_texture.getTexture(), 
+        sf::IntRect(size * render_offset, 0, size, size)
+    );
+	sprite.setScale(scale, scale);
+    return sprite;
 }
 
 sf::Sprite SpriteSheet::CreateTileSprite(int tile_map_x, int tile_map_y, int scale, int size) {
@@ -35,6 +55,22 @@ sf::Sprite SpriteSheet::CreateTileSprite(int tile_map_x, int tile_map_y, int sca
 	return sprite;
 }
 
-int SpriteSheet::SpriteSize() const {
+int SpriteSheet::GetSpriteSize() const {
   return scale * size;
+}
+
+int SpriteSheet::GetScale() const {
+    return scale;
+}
+
+int SpriteSheet::GetSize() const {
+    return size;
+}
+
+const sf::Texture& SpriteSheet::GetTexture() {
+    return texture;
+}
+
+std::vector<sf::Sprite> SpriteSheet::GetSprites() {
+    return sprites;
 }

--- a/src/TilePaletteView.cpp
+++ b/src/TilePaletteView.cpp
@@ -20,8 +20,8 @@ TilePaletteView::TilePaletteView(
     });
 
     auto entity_sprites = entity_map.GetSprites();
-    tiles.push_back(TilePaletteTile{entity_sprites[0], PaletteEntity, GhostEntity});
-    tiles.push_back(TilePaletteTile{entity_sprites[1], PaletteEntity, DoorEntity});
+    tiles.push_back(TilePaletteTile{entity_sprites[0], PaletteEntity, EntityType::GhostEntity});
+    tiles.push_back(TilePaletteTile{entity_sprites[1], PaletteEntity, EntityType::DoorEntity});
 
  
     auto left_toolbar_width = offset * 2 + tile_map.GetSpriteSize();

--- a/src/TilePaletteView.cpp
+++ b/src/TilePaletteView.cpp
@@ -2,31 +2,30 @@
 
 TilePaletteView::TilePaletteView(
     SpriteSheet &tile_map, 
+    SpriteSheet &entity_map, 
     int window_height
 ) : offset(20),
     selected_tile_index(0),
-    selection_rectangle(sf::Vector2f(tile_map.SpriteSize(), tile_map.SpriteSize())),
-    tile_map(tile_map) {
+    selection_rectangle(sf::Vector2f(tile_map.GetSpriteSize(), tile_map.GetSpriteSize())),
+    tile_map(tile_map), 
+    entity_map(entity_map) {
 
     selection_rectangle.setOutlineColor(sf::Color::Blue);
     selection_rectangle.setOutlineThickness(2);
     selection_rectangle.setFillColor(sf::Color::Transparent);
 
-    for (const auto &t: *tile_map.tiles) {
-        tiles.push_back(TilePaletteTile{t, PaletteTile});
-    }
+    auto tile_sprites = tile_map.GetSprites();
+    std::for_each(tile_sprites.begin(), tile_sprites.end(), [this](sf::Sprite &sprite){ 
+        tiles.push_back(TilePaletteTile{sprite, PaletteTile});
+    });
+
+    auto entity_sprites = entity_map.GetSprites();
+    tiles.push_back(TilePaletteTile{entity_sprites[0], PaletteEntity, GhostEntity});
+    tiles.push_back(TilePaletteTile{entity_sprites[1], PaletteEntity, DoorEntity});
+
  
-
-    icon_sprite_render_texture.create(tile_map.SpriteSize() * 2, tile_map.SpriteSize());
-    auto door_palette_sprite_icon = CreateIconSprite(tile_map.SpriteSize(), sf::Color::Red, 0);
-    tiles.push_back(TilePaletteTile{door_palette_sprite_icon, PaletteEntity, DoorEntity });
-
-    auto ghost_palette_sprite_icon = CreateIconSprite(tile_map.SpriteSize(), sf::Color::Green, 1);
-    tiles.push_back(TilePaletteTile{ghost_palette_sprite_icon, PaletteEntity, GhostEntity });
-
-
-    auto left_toolbar_width = offset * 2 + tile_map.SpriteSize();
-    auto total_height = (tiles.size() * (tile_map.SpriteSize() + offset)) + offset;
+    auto left_toolbar_width = offset * 2 + tile_map.GetSpriteSize();
+    auto total_height = (tiles.size() * (tile_map.GetSpriteSize() + offset)) + offset;
     background = sf::RectangleShape(sf::Vector2f(left_toolbar_width, total_height));
     background.setFillColor(sf::Color(60,60,60, 255));
 
@@ -37,25 +36,12 @@ TilePaletteView::TilePaletteView(
 TilePaletteView::~TilePaletteView() {
 }
 
-sf::Sprite TilePaletteView::CreateIconSprite(int sprite_size, sf::Color color, int render_offset) {
-    auto icon_rect = sf::RectangleShape(sf::Vector2f(sprite_size, sprite_size));
-    icon_rect.setFillColor(color);
-    icon_rect.setPosition(sprite_size * render_offset, 0);
-    icon_sprite_render_texture.draw(icon_rect);
-    icon_sprite_render_texture.display();
-
-    return sf::Sprite(
-        icon_sprite_render_texture.getTexture(), 
-        sf::IntRect(sprite_size * render_offset, 0, sprite_size, sprite_size)
-    );
-}
-
 void TilePaletteView::Update(const sf::Event & event, const sf::Vector2i) {
 
     selection_rectangle.setPosition(tiles[selected_tile_index].icon.getPosition());
     for(std::size_t i = 0; i < tiles.size(); i ++) {
         int current_y_pos = 
-            (i * tile_map.SpriteSize()) + 
+            (i * tile_map.GetSpriteSize()) + 
             (offset * i) + offset;
         tiles[i].icon.setPosition(offset, current_y_pos);
     }
@@ -109,8 +95,8 @@ int TilePaletteView::GetSelectedTileIndex() const {
     return selected_tile_index;
 }
 
-const sf::Sprite& TilePaletteView::GetSelectedTileSprite() const {
-    return tiles[selected_tile_index].icon;
+const TilePaletteTile& TilePaletteView::GetSelectedTile() const {
+    return tiles[selected_tile_index];
 }
 
 const sf::RectangleShape &TilePaletteView::GetBackground() const {

--- a/src/TilePaletteView.cpp
+++ b/src/TilePaletteView.cpp
@@ -15,7 +15,7 @@ TilePaletteView::TilePaletteView(
     selection_rectangle.setFillColor(sf::Color::Transparent);
 
     auto tile_sprites = tile_map.GetSprites();
-    std::for_each(tile_sprites.begin(), tile_sprites.end(), [this](sf::Sprite &sprite){ 
+    std::for_each(tile_sprites.begin(), tile_sprites.end(), [this](const auto &sprite){ 
         tiles.push_back(TilePaletteTile{sprite, PaletteTile});
     });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
         {"idle", Animation(player_sprite_sheet, idle_frames, 32, 32, 8) },
         {"walk", Animation(player_sprite_sheet, walk_frames, 32, 32, 8) }
     };
-    Entity player = Entity(PlayerEntity, 500.f, .01f, player_animations);
+    Entity player = Entity(EntityType::PlayerEntity, 500.f, .01f, player_animations);
     
     Map map = argc == 2 ? Map(argv[1]) : Map(20, 20, window_height, window_width);
     HouseScene house_scene(tile_map, entity_map, window_height, window_width, map, player);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,8 +7,8 @@
 
 int main(int argc, char** argv)
 {
-    int window_width = 1400;
-    int window_height = 1400;
+    int window_width = 1000;
+    int window_height = 1000;
     sf::RenderWindow window(sf::VideoMode(window_width, window_height), "SFML works!");
     window.setFramerateLimit(60);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,11 @@ int main(int argc, char** argv)
         7
     );
 
+    SpriteSheet entity_map(
+        4, // Tile scale factor
+        16
+    );
+
     SpriteSheet player_sprite_sheet(
         "./assets/NightThief.png", 
         4, // Tile scale factor
@@ -45,7 +50,7 @@ int main(int argc, char** argv)
     Entity player = Entity(PlayerEntity, 500.f, .01f, player_animations);
     
     Map map = argc == 2 ? Map(argv[1]) : Map(20, 20, window_height, window_width);
-    HouseScene house_scene(tile_map, window_height, window_width, map, player);
+    HouseScene house_scene(tile_map, entity_map, window_height, window_width, map, player);
 
     while (window.isOpen())
     {


### PR DESCRIPTION
Added an entity system with map layers

1. Entities can now be both defined as well as added to the map
2. Entities have an entity type that will allow attaching different behavior in the future such as power ups and loot. 
3. Maps now have layers allowing sprites to sit on top of other sprites. Currently there is no way to select what layer you have active in the editor though
4. Used `std::for_each` after watching "No raw Loops". Awesome talk! Will start to try and refactor some other loops as I touch them. 
5. Extracted sprite sheet out of the `TilePaletteView`. I'd say that `SpriteSheet` still needs some cleanup however its a little more generic now.
