### PR TITLE
Update `current_mouse_position` handling

### DIFF
--- a/headers/HouseScene.h
+++ b/headers/HouseScene.h
@@ -37,7 +37,7 @@ public:
     HouseScene(SpriteSheet &, int, int, Map &, Entity &);
     ~HouseScene();
     void Draw(sf::RenderTarget &);
-    void Update(const sf::Event &, const sf::Vector2i);
+    void Update(const sf::Event &, const sf::Vector2i &);
 };
 
 

--- a/src/HouseScene.cpp
+++ b/src/HouseScene.cpp
@@ -23,7 +23,7 @@ HouseScene::HouseScene(
 HouseScene::~HouseScene() {
 }
 
-void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse_position) {
+void HouseScene::Update(const sf::Event& event, const sf::Vector2i &current_mouse_position) {
     if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::E) {
         editor_enabled = !editor_enabled;
         player.Reset();
@@ -36,8 +36,8 @@ void HouseScene::Update(const sf::Event& event, const sf::Vector2i current_mouse
 
     tile_palette_view.Update(event, current_mouse_position);
 
-    sf::Vector2f current_target_coords = house_render_texture.mapPixelToCoords(
-            sf::Vector2i(current_mouse_position.x, current_mouse_position.y)
+    auto current_target_coords = house_render_texture.mapPixelToCoords(
+        current_mouse_position
     );
 
     current_mouse_grid_position.x = floor(current_target_coords.x / tile_map.SpriteSize());


### PR DESCRIPTION
Update `HouseScene::Update` to accept the `current_mouse_position`
by reference, and to not copy-construct another `sf::Vector2i`
unnecessarily