### PR TITLE
Reset frame counter right at the end

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -21,7 +21,7 @@ void Animation::Update ()  {
     );
 
     sprite.setTextureRect(current_frame_rect);
-    if (current_frame_counter == (animation_frames.size() * speed) - (speed * 2)) {
+    if (current_frame_counter == (animation_frames.size() * speed) - 1) {
         current_frame_counter = 0;
     } else {
         current_frame_counter++;


### PR DESCRIPTION
Reset the animation frame counter at the last valid point, so each
frame will get the same amount of repeats (based on speed)