### PR TITLE
Use the `width` and `height` fields on `sf::IntRect`

### DIFF
--- a/src/EditorController.cpp
+++ b/src/EditorController.cpp
@@ -65,9 +65,9 @@ void EditorController::HandleInput (const EventWithMouse event_with_mouse, House
     }
 
     if (event_with_mouse.event.type == sf::Event::MouseWheelMoved && 
-        event_with_mouse.event.mouseButton.x < reducer.GetState().editor_state.tile_palette_bounds.getSize().x
+        event_with_mouse.event.mouseButton.x < reducer.GetState().editor_state.tile_palette_bounds.width
     ) {
-        int upper_scroll_center = reducer.GetState().editor_state.tile_palette_bounds.getSize().y / 2;
+        int upper_scroll_center = reducer.GetState().editor_state.tile_palette_bounds.height / 2;
 
         int lower_scroll_center = 
             reducer.GetState().editor_state.tile_palette_background_total_height - 


### PR DESCRIPTION
Fix a small issue with previous use of `getSize()` to get the
dimensions of the tile palette, which is now stored as a
`sf::IntRect`