### PR TITLE
Always use `EventWithMouse` instances as const ref

### DIFF
--- a/headers/Controller.h
+++ b/headers/Controller.h
@@ -8,6 +8,6 @@ class Controller {
 public:
     virtual ~Controller() = default;
     virtual void Update(T&) = 0;
-    virtual void HandleInput(const EventWithMouse, T&) = 0;
+    virtual void HandleInput(const EventWithMouse &, T&) = 0;
 };
 

--- a/headers/EditorController.h
+++ b/headers/EditorController.h
@@ -13,11 +13,11 @@ class EditorController : public Controller<HouseSceneReducer> {
     sf::Vector2i last_mouse_position;
     Map& map;
 
-    void HandleInputBoxSelection(EventWithMouse, HouseSceneReducer&);
+    void HandleInputBoxSelection(const EventWithMouse &, HouseSceneReducer&);
 public:
     EditorController(int, sf::RenderTexture&, sf::RenderTexture&, Map&);
     void Update(HouseSceneReducer&);
-    void HandleInput(EventWithMouse, HouseSceneReducer&);
+    void HandleInput(const EventWithMouse &, HouseSceneReducer&);
 };
 
 

--- a/headers/EventWithMouse.h
+++ b/headers/EventWithMouse.h
@@ -3,7 +3,7 @@
 #include <SFML/Window.hpp>
 
 struct EventWithMouse {
-    sf::Event& event;
-    sf::Vector2i window_mouse_position;
+    const sf::Event& event;
+    const sf::Vector2i &window_mouse_position;
 };
 

--- a/headers/PlayerController.h
+++ b/headers/PlayerController.h
@@ -10,7 +10,7 @@ class PlayerController : public Controller<HouseSceneReducer> {
 public:
     PlayerController();
     void Update(HouseSceneReducer&);
-    void HandleInput(EventWithMouse, HouseSceneReducer&);
+    void HandleInput(const EventWithMouse &, HouseSceneReducer&);
     void Reset();
 };
 

--- a/src/EditorController.cpp
+++ b/src/EditorController.cpp
@@ -26,7 +26,7 @@ void EditorController::Update (HouseSceneReducer& reducer) {
 
 }
 
-void EditorController::HandleInput (const EventWithMouse event_with_mouse, HouseSceneReducer& reducer) {
+void EditorController::HandleInput (const EventWithMouse &event_with_mouse, HouseSceneReducer& reducer) {
    
     if (event_with_mouse.event.type == sf::Event::KeyPressed && 
         event_with_mouse.event.key.code == sf::Keyboard::E) {
@@ -182,7 +182,7 @@ void EditorController::HandleInput (const EventWithMouse event_with_mouse, House
 }
 
 void EditorController::HandleInputBoxSelection (
-    EventWithMouse event_with_mouse, 
+    const EventWithMouse &event_with_mouse, 
     HouseSceneReducer& reducer
 ) {
         

--- a/src/PlayerController.cpp
+++ b/src/PlayerController.cpp
@@ -2,7 +2,7 @@
 
 PlayerController::PlayerController() {}
 
-void PlayerController::HandleInput (EventWithMouse event_with_mouse, HouseSceneReducer &state) {
+void PlayerController::HandleInput (const EventWithMouse &event_with_mouse, HouseSceneReducer &state) {
 
     if (event_with_mouse.event.type == sf::Event::KeyPressed && event_with_mouse.event.key.code == sf::Keyboard::Left) {
         current_input = sf::Vector2f(-1, 0);


### PR DESCRIPTION
Change function declarations to enforce `EventWithMouse` uses as
constant references