### PR TITLE
Move `ViewLayer::views` to `std::unique_ptr`

### DIFF
--- a/headers/ViewLayer.h
+++ b/headers/ViewLayer.h
@@ -5,12 +5,12 @@
 #include "HouseSceneState.h"
 
 class ViewLayer {
-    std::vector<std::shared_ptr<View<HouseSceneState>>> views;
+    std::vector<std::unique_ptr<View<HouseSceneState>>> views;
     sf::RenderTexture render_texture;
 public: 
     ViewLayer(int, int);
     void Draw(sf::RenderTarget&, const sf::View&, const HouseSceneState&);
-    void AddView(std::shared_ptr<View<HouseSceneState>> view);
+    void AddView(std::unique_ptr<View<HouseSceneState>> &&view);
     sf::RenderTexture& GetRenderTexture();
 };
 

--- a/src/ViewLayer.cpp
+++ b/src/ViewLayer.cpp
@@ -24,6 +24,6 @@ sf::RenderTexture& ViewLayer::GetRenderTexture() {
     return render_texture;
 }
 
-void ViewLayer::AddView(std::shared_ptr<View<HouseSceneState>> view) {
-    views.push_back(view);
+void ViewLayer::AddView(std::unique_ptr<View<HouseSceneState>> &&view) {
+    views.push_back(std::move(view));
 }


### PR DESCRIPTION
Move `ViewLayer::views` to `std::vector<std::unique_ptr<>>` and
update `ViewLayer::AddView` to both take an r-value, and ensure a
move into the `std::vector` with `std::move`. This matches all the
current call-sites, as they are all passed temporaries.