### PR TITLE
Remove use of `numbers`

### DIFF
--- a/src/PlayerController.cpp
+++ b/src/PlayerController.cpp
@@ -1,5 +1,4 @@
 #include <cmath>
-#include <numbers>
 #include "PlayerController.h"
 
 PlayerController::PlayerController(


### PR DESCRIPTION
The `numbers` header isn't being used, and is C++20 (which my
stock macOS compiler doesn't support) so I figure this can be
removed until needed