### PR TITLE
Asset watcher thread shutdown

### DIFF
--- a/headers/AssetWatcher.h
+++ b/headers/AssetWatcher.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#include <map>
 #include <string>
 #include <thread>
-#include <map>
 
 #include "SpriteSheet.h"
-
 
 class AssetWatcher {
     std::thread watcher;
@@ -13,6 +12,7 @@ class AssetWatcher {
     std::map<std::string, std::shared_ptr<SpriteSheet>> sprite_sheets;
     void Reload();
     std::atomic<bool> required_reload;
+
   public:
     void ReloadIfRequired();
     std::shared_ptr<SpriteSheet> GetSpriteSheet(std::string);

--- a/headers/AssetWatcher.h
+++ b/headers/AssetWatcher.h
@@ -12,6 +12,7 @@ class AssetWatcher {
     std::map<std::string, std::shared_ptr<SpriteSheet>> sprite_sheets;
     void Reload();
     std::atomic<bool> required_reload;
+    std::atomic<bool> shutdown;
 
   public:
     void ReloadIfRequired();

--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -48,7 +48,7 @@ void AssetWatcher::StartWatching() {
         }
 
         directory_watch_wait_status = WaitForMultipleObjects(
-            1, directory_watcher_change_handles, false, INFINITE);
+            1, directory_watcher_change_handles, false, 5000);
 
         if (directory_watch_wait_status == WAIT_OBJECT_0) {
             Sleep(10); // TODO : I think there is a race conidition here and the

--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -4,7 +4,8 @@
 #include "AssetWatcher.h"
 
 AssetWatcher::AssetWatcher(int scale)
-    : watcher(&AssetWatcher::StartWatching, this), required_reload(false) {
+    : watcher(&AssetWatcher::StartWatching, this), required_reload(false),
+      shutdown(false) {
 
     sprite_sheets["tile_map"] =
         std::make_shared<SpriteSheet>("./assets/house.png", scale, 16, 20, 20);
@@ -18,7 +19,10 @@ AssetWatcher::AssetWatcher(int scale)
         std::make_shared<SpriteSheet>(scale, 8);
 }
 
-AssetWatcher::~AssetWatcher() { watcher.join(); }
+AssetWatcher::~AssetWatcher() {
+    shutdown = true;
+    watcher.join();
+}
 
 std::shared_ptr<SpriteSheet>
 AssetWatcher::GetSpriteSheet(std::string sprite_sheet_name) {
@@ -39,7 +43,7 @@ void AssetWatcher::StartWatching() {
     DWORD directory_watch_wait_status;
     strcpy(lp_asset_path, asset_path.c_str());
 
-    while (true) {
+    while (!shutdown) {
         directory_watcher_change_handles[0] = FindFirstChangeNotification(
             lp_asset_path, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 


### PR DESCRIPTION
Allow (semi)graceful termination of the `AssetWatcher` when shutting down.

This avoids the infinitely long wait when closing the main window.