### PR TITLE
Asset watcher wait for single object

### DIFF
--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -32,14 +32,11 @@ void AssetWatcher::Reload() {
 }
 
 void AssetWatcher::StartWatching() {
-    std::string asset_path =
-        "C:\\Users\\Stewart\\SourceCode\\projectx\\build\\assets";
-    LPTSTR lp_asset_path = new TCHAR[asset_path.size() + 1];
-    strcpy(lp_asset_path, asset_path.c_str());
+    auto asset_path = "C:\\Users\\Stewart\\SourceCode\\projectx\\build\\assets";
 
     while (true) {
         auto directory_watcher_change_handle = FindFirstChangeNotification(
-            lp_asset_path, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
+            asset_path, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 
         if (directory_watcher_change_handle == INVALID_HANDLE_VALUE) {
             exit(GetLastError());
@@ -54,8 +51,6 @@ void AssetWatcher::StartWatching() {
             required_reload = true;
         }
     }
-
-    delete[] lp_asset_path;
 }
 
 void AssetWatcher::ReloadIfRequired() {

--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -5,23 +5,23 @@
 
 AssetWatcher::AssetWatcher(int scale)
     : watcher(&AssetWatcher::StartWatching, this), required_reload(false) {
-	
-	sprite_sheets["tile_map"] =
+
+    sprite_sheets["tile_map"] =
         std::make_shared<SpriteSheet>("./assets/house.png", scale, 16, 20, 20);
 
     sprite_sheets["entity_map"] = std::make_shared<SpriteSheet>(scale, 16);
 
-    sprite_sheets["player_sprite_sheet"] = 
-		std::make_shared<SpriteSheet>("./assets/NightThief.png", scale, 320, 1, 1);
+    sprite_sheets["player_sprite_sheet"] = std::make_shared<SpriteSheet>(
+        "./assets/NightThief.png", scale, 320, 1, 1);
 
-    sprite_sheets["toolbar_sprite_sheet"] = std::make_shared<SpriteSheet>(scale, 8);
+    sprite_sheets["toolbar_sprite_sheet"] =
+        std::make_shared<SpriteSheet>(scale, 8);
 }
 
-AssetWatcher::~AssetWatcher() {
-	watcher.join(); 
-}
+AssetWatcher::~AssetWatcher() { watcher.join(); }
 
-std::shared_ptr<SpriteSheet> AssetWatcher::GetSpriteSheet(std::string sprite_sheet_name) {
+std::shared_ptr<SpriteSheet>
+AssetWatcher::GetSpriteSheet(std::string sprite_sheet_name) {
     return sprite_sheets[sprite_sheet_name];
 }
 
@@ -32,43 +32,37 @@ void AssetWatcher::Reload() {
 }
 
 void AssetWatcher::StartWatching() {
-	std::string asset_path = "C:\\Users\\Stewart\\SourceCode\\projectx\\build\\assets";
-	HANDLE directory_watcher_change_handles[1];
+    std::string asset_path =
+        "C:\\Users\\Stewart\\SourceCode\\projectx\\build\\assets";
+    HANDLE directory_watcher_change_handles[1];
     LPTSTR lp_asset_path = new TCHAR[asset_path.size() + 1];
     DWORD directory_watch_wait_status;
     strcpy(lp_asset_path, asset_path.c_str());
 
-	while (true) {
-		directory_watcher_change_handles[0] = FindFirstChangeNotification(
-			lp_asset_path,
-			false,
-			FILE_NOTIFY_CHANGE_LAST_WRITE
-		);
+    while (true) {
+        directory_watcher_change_handles[0] = FindFirstChangeNotification(
+            lp_asset_path, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 
-		if (directory_watcher_change_handles[0] == INVALID_HANDLE_VALUE) {
-			exit(GetLastError());
-		}
+        if (directory_watcher_change_handles[0] == INVALID_HANDLE_VALUE) {
+            exit(GetLastError());
+        }
 
-		directory_watch_wait_status = WaitForMultipleObjects(
-			1, 
-			directory_watcher_change_handles, 
-			false, 
-			INFINITE
-		);
+        directory_watch_wait_status = WaitForMultipleObjects(
+            1, directory_watcher_change_handles, false, INFINITE);
 
-		if (directory_watch_wait_status == WAIT_OBJECT_0) {
-            Sleep(10); // TODO : I think there is a race conidition here and the file is still locked
+        if (directory_watch_wait_status == WAIT_OBJECT_0) {
+            Sleep(10); // TODO : I think there is a race conidition here and the
+                       // file is still locked
             required_reload = true;
-		}
+        }
     }
-    
-	delete[] lp_asset_path;
+
+    delete[] lp_asset_path;
 }
 
 void AssetWatcher::ReloadIfRequired() {
     if (required_reload) {
-		Reload();
-		required_reload = false;
+        Reload();
+        required_reload = false;
     }
 }
-

--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -34,21 +34,19 @@ void AssetWatcher::Reload() {
 void AssetWatcher::StartWatching() {
     std::string asset_path =
         "C:\\Users\\Stewart\\SourceCode\\projectx\\build\\assets";
-    HANDLE directory_watcher_change_handles[1];
     LPTSTR lp_asset_path = new TCHAR[asset_path.size() + 1];
-    DWORD directory_watch_wait_status;
     strcpy(lp_asset_path, asset_path.c_str());
 
     while (true) {
-        directory_watcher_change_handles[0] = FindFirstChangeNotification(
+        auto directory_watcher_change_handle = FindFirstChangeNotification(
             lp_asset_path, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 
-        if (directory_watcher_change_handles[0] == INVALID_HANDLE_VALUE) {
+        if (directory_watcher_change_handle == INVALID_HANDLE_VALUE) {
             exit(GetLastError());
         }
 
-        directory_watch_wait_status = WaitForMultipleObjects(
-            1, directory_watcher_change_handles, false, INFINITE);
+        auto directory_watch_wait_status =
+            WaitForSingleObject(directory_watcher_change_handle, INFINITE);
 
         if (directory_watch_wait_status == WAIT_OBJECT_0) {
             Sleep(10); // TODO : I think there is a race conidition here and the


### PR DESCRIPTION
Not actually tested, beyond mocking out with a win32 shim, but basically involves moving from `WaitForMultipleObjects` to `WaitForSingleObject` given that only one handle is being waited on.