### PR TITLE
Asset watcher dynamic path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(ProjectX VERSION 1.0)
 set(CMAKE_CXX_EXTENSIONS OFF)
 #set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -fsanitize=address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -32,16 +32,18 @@ void AssetWatcher::Reload() {
 }
 
 void AssetWatcher::StartWatching() {
-    std::string asset_path =
-        "C:\\Users\\Stewart\\SourceCode\\projectx\\build\\assets";
+    char buffer[MAX_PATH];
+    // TODO: consider handling the case where path name greater than length
+    if (GetFullPathName("assets", MAX_PATH, buffer, nullptr) == 0) {
+        exit(GetLastError());
+    }
+
     HANDLE directory_watcher_change_handles[1];
-    LPTSTR lp_asset_path = new TCHAR[asset_path.size() + 1];
     DWORD directory_watch_wait_status;
-    strcpy(lp_asset_path, asset_path.c_str());
 
     while (true) {
         directory_watcher_change_handles[0] = FindFirstChangeNotification(
-            lp_asset_path, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
+            buffer, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 
         if (directory_watcher_change_handles[0] == INVALID_HANDLE_VALUE) {
             exit(GetLastError());
@@ -56,8 +58,6 @@ void AssetWatcher::StartWatching() {
             required_reload = true;
         }
     }
-
-    delete[] lp_asset_path;
 }
 
 void AssetWatcher::ReloadIfRequired() {

--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <iostream>
 #include <windows.h>
 
@@ -32,18 +33,14 @@ void AssetWatcher::Reload() {
 }
 
 void AssetWatcher::StartWatching() {
-    char buffer[MAX_PATH];
-    // TODO: consider handling the case where path name greater than length
-    if (GetFullPathName("assets", MAX_PATH, buffer, nullptr) == 0) {
-        exit(GetLastError());
-    }
+    auto asset_path = std::filesystem::absolute("assets");
 
     HANDLE directory_watcher_change_handles[1];
     DWORD directory_watch_wait_status;
 
     while (true) {
         directory_watcher_change_handles[0] = FindFirstChangeNotification(
-            buffer, false, FILE_NOTIFY_CHANGE_LAST_WRITE);
+            asset_path.string().c_str(), false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 
         if (directory_watcher_change_handles[0] == INVALID_HANDLE_VALUE) {
             exit(GetLastError());


### PR DESCRIPTION
This moves from reading a hard coded asset path to one relative to the current working directory.

I had tested plugging a relative path directly into `FindFirstChangeNotification`, and that worked, but according to the [docs][1]:

> This cannot be a relative path or an empty string.

so I guess better safe than sorry 🤷🏻‍♂️ 

[1]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstchangenotificationa

