### PR TITLE
Add include for `atomic` and `memory` headers

### DIFF
--- a/headers/Animation.h
+++ b/headers/Animation.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "SpriteSheet.h"
 
 struct AnimationFrame {

--- a/headers/AssetWatcher.h
+++ b/headers/AssetWatcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <thread>
 #include <map>


### PR DESCRIPTION
When compiling with g++ 10.3.0, used of `std::atomic` and
`std::shared_ptr` need the appropriate headers