### PR TITLE
Determine and link against threading implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,3 +100,8 @@ if(DEFINED ENV{SFML_PREFIX})
     PRIVATE $ENV{SFML_PREFIX}/lib
   )
 endif()
+
+find_package(Threads REQUIRED)
+target_link_libraries(ProjectX
+  Threads::Threads
+)


### PR DESCRIPTION
Linux needs `pthread` to be linked in, so add a dependency on the
CMake `Threads` package to bring it in