### PR TITLE
Debug warning fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(ProjectX VERSION 1.0)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
-#set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -fsanitize=address -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -fsanitize=address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/headers/GamepadControllerScheme.h
+++ b/headers/GamepadControllerScheme.h
@@ -1,8 +1,9 @@
 #pragma once
+
 #include "ControllerScheme.h"
 #include "EventWithMouse.h"
 
 class GamepadControllerScheme : public ControllerScheme {
   public:
-	 ControllerSchemeState GetInput(const EventWithMouse&) const;
+    ControllerSchemeState GetInput(const EventWithMouse &) const;
 };

--- a/headers/GamepadControllerScheme.h
+++ b/headers/GamepadControllerScheme.h
@@ -3,7 +3,7 @@
 #include "ControllerScheme.h"
 #include "EventWithMouse.h"
 
-class GamepadControllerScheme : public ControllerScheme {
+class GamepadControllerScheme final : public ControllerScheme {
   public:
     ControllerSchemeState GetInput(const EventWithMouse &) const;
 };

--- a/headers/KeyboardControllerScheme.h
+++ b/headers/KeyboardControllerScheme.h
@@ -2,7 +2,7 @@
 
 #include "ControllerScheme.h"
 
-class KeyboardControllerScheme : public ControllerScheme {
+class KeyboardControllerScheme final : public ControllerScheme {
   public:
     ControllerSchemeState GetInput(const EventWithMouse &) const;
 };

--- a/headers/KeyboardControllerScheme.h
+++ b/headers/KeyboardControllerScheme.h
@@ -4,5 +4,5 @@
 
 class KeyboardControllerScheme : public ControllerScheme {
   public:
-	ControllerSchemeState GetInput(const EventWithMouse&) const;
+    ControllerSchemeState GetInput(const EventWithMouse &) const;
 };


### PR DESCRIPTION
My understanding, pieced together from:

  https://stackoverflow.com/questions/43282826/suppress-delete-non-virtual-dtor-warning-when-using-a-protected-non-virtual-dest

is that this can be an issue whenever a pointer of the base class is assigned an instance of the overriding class. In that case, the non-virtual destructor of the base class could be invoked (directly or via `delete`), not the destructor of the overriding
class.

Viz:

```
#include <cstdio>
#include <cstdlib>

struct Foo {
    virtual void allocate(size_t count) = 0;
};

struct Bar : Foo {
    void *buffer = nullptr;

    void allocate(size_t count) override {
        printf("Bar::allocate:  allocating buffer\n");
        buffer = malloc(count);
    }

    ~Bar() {
        printf("Bar::~Bar:      freeing buffer\n");
        free(buffer);
    }
};

int main() {
    Bar *bar_bar = new Bar();
    bar_bar->allocate(42);
    delete bar_bar;

    Foo *foo_bar = new Bar();
    foo_bar->allocate(42);
    delete foo_bar;
}
```

would print:

```
Bar::allocate:  allocating buffer
Bar::~Bar:      freeing buffer
Bar::allocate:  allocating buffer
```

i.e, the second use is unsound.

Our case is in fact sound (it's effectively the first use, deep inside `std::make_shared`) but it could be a problem if either the
`ControllerScheme` implementations were overridden, so making them `final` ensures this particular use won't be a problem.
