### PR TITLE
Reinstate 5000ms timeout in watcher

### DIFF
--- a/src/AssetWatcher.cpp
+++ b/src/AssetWatcher.cpp
@@ -52,7 +52,7 @@ void AssetWatcher::StartWatching() {
         }
 
         auto directory_watch_wait_status =
-            WaitForSingleObject(directory_watcher_change_handle, INFINITE);
+            WaitForSingleObject(directory_watcher_change_handle, 5000);
 
         if (directory_watch_wait_status == WAIT_OBJECT_0) {
             Sleep(10); // TODO : I think there is a race conidition here and the


### PR DESCRIPTION
This was dropped in the merges too.

5000ms is just a random figure I arrived at; basically it means that on shutdown you may have to wait up to 5 seconds before it will actually shutdown.