### PR TITLE
Controller optional input

### DIFF
--- a/headers/ControllerScheme.h
+++ b/headers/ControllerScheme.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+
 #include "EventWithMouse.h"
 
 struct ControllerSchemeState {
@@ -11,6 +12,6 @@ struct ControllerSchemeState {
 
 class ControllerScheme {
 
-public:
-	virtual ControllerSchemeState GetInput(const EventWithMouse&) const = 0;
+  public:
+    virtual ControllerSchemeState GetInput(const EventWithMouse &) const = 0;
 };

--- a/headers/ControllerScheme.h
+++ b/headers/ControllerScheme.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <SFML/Graphics.hpp>
 
 #include "EventWithMouse.h"
@@ -13,5 +15,6 @@ struct ControllerSchemeState {
 class ControllerScheme {
 
   public:
-    virtual ControllerSchemeState GetInput(const EventWithMouse &) const = 0;
+    virtual std::optional<ControllerSchemeState>
+    GetInput(const EventWithMouse &) const = 0;
 };

--- a/headers/GamepadControllerScheme.h
+++ b/headers/GamepadControllerScheme.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <optional>
+
 #include "ControllerScheme.h"
 #include "EventWithMouse.h"
 
 class GamepadControllerScheme final : public ControllerScheme {
   public:
-    ControllerSchemeState GetInput(const EventWithMouse &) const;
+    std::optional<ControllerSchemeState> GetInput(const EventWithMouse &) const;
 };

--- a/headers/KeyboardControllerScheme.h
+++ b/headers/KeyboardControllerScheme.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <optional>
+
 #include "ControllerScheme.h"
 
 class KeyboardControllerScheme final : public ControllerScheme {
   public:
-    ControllerSchemeState GetInput(const EventWithMouse &) const;
+    std::optional<ControllerSchemeState> GetInput(const EventWithMouse &) const;
 };

--- a/src/GamepadControllerScheme.cpp
+++ b/src/GamepadControllerScheme.cpp
@@ -1,22 +1,24 @@
-#include "GamepadControllerScheme.h"
-#include <iostream>
 #include <algorithm>
+#include <iostream>
+
 #include <SFML/Window/Joystick.hpp>
+
+#include "GamepadControllerScheme.h"
 
 const int PLAYER_ONE_JOYSTICK_ID = 1;
 const int LOOT_ACTION_BUTTON_ID = 1;
 const int ATTACK_ACTION_BUTTON_ID = 2;
 
-ControllerSchemeState GamepadControllerScheme::GetInput(const EventWithMouse &) const {
-
+ControllerSchemeState
+GamepadControllerScheme::GetInput(const EventWithMouse &) const {
 
     float x = sf::Joystick::getAxisPosition(0, sf::Joystick::X) / 100;
     float y = sf::Joystick::getAxisPosition(0, sf::Joystick::Y) / 100;
-    bool loot_action_pressed =
-        sf::Joystick::isButtonPressed(PLAYER_ONE_JOYSTICK_ID, LOOT_ACTION_BUTTON_ID);
-    
-    bool attack_pressed =
-        sf::Joystick::isButtonPressed(PLAYER_ONE_JOYSTICK_ID, ATTACK_ACTION_BUTTON_ID);
+    bool loot_action_pressed = sf::Joystick::isButtonPressed(
+        PLAYER_ONE_JOYSTICK_ID, LOOT_ACTION_BUTTON_ID);
+
+    bool attack_pressed = sf::Joystick::isButtonPressed(
+        PLAYER_ONE_JOYSTICK_ID, ATTACK_ACTION_BUTTON_ID);
 
     float threshhold = .08f;
 
@@ -28,5 +30,5 @@ ControllerSchemeState GamepadControllerScheme::GetInput(const EventWithMouse &) 
         y = 0;
     }
 
-    return { sf::Vector2f(x, y), loot_action_pressed, attack_pressed };
+    return {sf::Vector2f(x, y), loot_action_pressed, attack_pressed};
 }

--- a/src/GamepadControllerScheme.cpp
+++ b/src/GamepadControllerScheme.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <iostream>
+#include <optional>
 
 #include <SFML/Window/Joystick.hpp>
 
@@ -9,7 +10,7 @@ const int PLAYER_ONE_JOYSTICK_ID = 1;
 const int LOOT_ACTION_BUTTON_ID = 1;
 const int ATTACK_ACTION_BUTTON_ID = 2;
 
-ControllerSchemeState
+std::optional<ControllerSchemeState>
 GamepadControllerScheme::GetInput(const EventWithMouse &) const {
 
     float x = sf::Joystick::getAxisPosition(0, sf::Joystick::X) / 100;
@@ -30,5 +31,5 @@ GamepadControllerScheme::GetInput(const EventWithMouse &) const {
         y = 0;
     }
 
-    return {sf::Vector2f(x, y), loot_action_pressed, attack_pressed};
+    return {{sf::Vector2f(x, y), loot_action_pressed, attack_pressed}};
 }

--- a/src/KeyboardControllerScheme.cpp
+++ b/src/KeyboardControllerScheme.cpp
@@ -1,6 +1,7 @@
 #include "KeyboardControllerScheme.h"
 
-ControllerSchemeState KeyboardControllerScheme::GetInput(const EventWithMouse& event_with_mouse) const {
+ControllerSchemeState KeyboardControllerScheme::GetInput(
+    const EventWithMouse &event_with_mouse) const {
     if (event_with_mouse.event.type == sf::Event::KeyPressed &&
         event_with_mouse.event.key.code == sf::Keyboard::Left) {
         return {sf::Vector2f(-1, 0), false, false};

--- a/src/KeyboardControllerScheme.cpp
+++ b/src/KeyboardControllerScheme.cpp
@@ -1,28 +1,30 @@
 #include "KeyboardControllerScheme.h"
 
-ControllerSchemeState KeyboardControllerScheme::GetInput(
+std::optional<ControllerSchemeState> KeyboardControllerScheme::GetInput(
     const EventWithMouse &event_with_mouse) const {
     if (event_with_mouse.event.type == sf::Event::KeyPressed &&
         event_with_mouse.event.key.code == sf::Keyboard::Left) {
-        return {sf::Vector2f(-1, 0), false, false};
+        return {{sf::Vector2f(-1, 0), false, false}};
     }
 
     if (event_with_mouse.event.type == sf::Event::KeyPressed &&
         event_with_mouse.event.key.code == sf::Keyboard::Right) {
-        return {sf::Vector2f(1, 0), false, false};
+        return {{sf::Vector2f(1, 0), false, false}};
     }
 
     if (event_with_mouse.event.type == sf::Event::KeyPressed &&
         event_with_mouse.event.key.code == sf::Keyboard::Up) {
-        return {sf::Vector2f(0, -1), false, false};
+        return {{sf::Vector2f(0, -1), false, false}};
     }
 
     if (event_with_mouse.event.type == sf::Event::KeyPressed &&
         event_with_mouse.event.key.code == sf::Keyboard::Down) {
-        return {sf::Vector2f(0, 1), false, false};
+        return {{sf::Vector2f(0, 1), false, false}};
     }
 
     if (event_with_mouse.event.type == sf::Event::KeyReleased) {
-        return {sf::Vector2f(0, 0), false, false};
+        return {{sf::Vector2f(0, 0), false, false}};
     }
+
+    return {};
 }

--- a/src/PlayerController.cpp
+++ b/src/PlayerController.cpp
@@ -1,5 +1,6 @@
-#include "PlayerController.h"
 #include <cmath>
+
+#include "PlayerController.h"
 
 PlayerController::PlayerController(
     std::shared_ptr<std::unordered_map<EntityState, Animation>> animations,

--- a/src/PlayerController.cpp
+++ b/src/PlayerController.cpp
@@ -11,7 +11,9 @@ PlayerController::PlayerController(
 
 void PlayerController::HandleInput(const EventWithMouse &event_with_mouse,
                                    HouseSceneReducer &) {
-    current_input = controller_scheme->GetInput(event_with_mouse);
+    if (auto input = controller_scheme->GetInput(event_with_mouse)) {
+        current_input = *input;
+    }
 }
 
 void PlayerController::Update(HouseSceneReducer &reducer, sf::Time delta_time) {


### PR DESCRIPTION
Make `ControllerScheme::GetInput` optional

Change the return type of `ControllerScheme::GetInput` to be
`std::optional<ControllerSchemeState>` to ensure that if a
controller scheme does not return an input, the caller can handle
this gracefully.