### PR TITLE
Asset watcher win32 find next change notification

### DIFF
--- a/src/AssetWatcher.win32.cpp
+++ b/src/AssetWatcher.win32.cpp
@@ -6,20 +6,26 @@
 void AssetWatcher::StartWatching() {
     auto asset_path = std::filesystem::absolute("assets");
 
+    auto change_handle = FindFirstChangeNotification(
+        asset_path.string().c_str(), false, FILE_NOTIFY_CHANGE_LAST_WRITE);
+
+    if (change_handle == INVALID_HANDLE_VALUE) {
+        exit(GetLastError());
+    }
+
     while (!shutdown) {
-        auto change_handle = FindFirstChangeNotification(
-            asset_path.string().c_str(), false, FILE_NOTIFY_CHANGE_LAST_WRITE);
-
-        if (change_handle == INVALID_HANDLE_VALUE) {
-            exit(GetLastError());
-        }
-
         auto wait_status = WaitForSingleObject(change_handle, 5000);
 
         if (wait_status == WAIT_OBJECT_0) {
             Sleep(10); // TODO : I think there is a race conidition here and the
                        // file is still locked
             required_reload = true;
+
+            if (FindNextChangeNotification(change_handle) == false) {
+                exit(GetLastError());
+            }
         }
     }
+
+    FindCloseChangeNotification(change_handle);
 }

--- a/src/AssetWatcher.win32.cpp
+++ b/src/AssetWatcher.win32.cpp
@@ -7,17 +7,16 @@ void AssetWatcher::StartWatching() {
     auto asset_path = std::filesystem::absolute("assets");
 
     while (!shutdown) {
-        auto directory_watcher_change_handle = FindFirstChangeNotification(
+        auto change_handle = FindFirstChangeNotification(
             asset_path.string().c_str(), false, FILE_NOTIFY_CHANGE_LAST_WRITE);
 
-        if (directory_watcher_change_handle == INVALID_HANDLE_VALUE) {
+        if (change_handle == INVALID_HANDLE_VALUE) {
             exit(GetLastError());
         }
 
-        auto directory_watch_wait_status =
-            WaitForSingleObject(directory_watcher_change_handle, 5000);
+        auto wait_status = WaitForSingleObject(change_handle, 5000);
 
-        if (directory_watch_wait_status == WAIT_OBJECT_0) {
+        if (wait_status == WAIT_OBJECT_0) {
             Sleep(10); // TODO : I think there is a race conidition here and the
                        // file is still locked
             required_reload = true;


### PR DESCRIPTION
Use `FindNextChangeNotification` and `FindCloseChangeNotification`

As per:

  https://docs.microsoft.com/en-us/windows/win32/fileio/obtaining-directory-change-notifications

create the handle using `FindFirstChangeNotification` outside the
loop, and use `FindNextChangeNotification` on receiving an event
for that handle. When exitting the thread, also call
`FindCloseChangeNotification` to more gracefully cease watching.